### PR TITLE
🎨 Palette: Improve TUI interactive selection UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-09 - TUI Keyboard Traps
+**Learning:** Terminal applications using raw mode often suppress system interrupts like `Ctrl-C` (`\x03`), causing keyboard traps where users can't easily exit menus. Additionally, omitting explicit choices in text prompts reduces discoverability.
+**Action:** Always map standard interrupt bytes (like `\x03`) to exit actions in raw mode TUI components, update footer text to advertise exit shortcuts (e.g. "Esc/Ctrl-C to cancel"), and always pass valid options to prompt libraries to ensure they are visible.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -67,7 +67,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = help_text or 'Use Up/Down arrows and Enter to select. Esc/Ctrl-C to cancel.'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +76,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title}", choices=options, default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:
@@ -99,7 +99,7 @@ class TerminalUI:
                 selected_index = (selected_index + 1) % len(options)
             elif key == 'enter':
                 return options[selected_index]
-            elif key == 'escape':
+            elif key in ('escape', '\x03'):
                 raise KeyboardInterrupt('Selection cancelled by user.')
             elif isinstance(key, str) and len(key) == 1:
                 lowered = key.lower()
@@ -110,7 +110,7 @@ class TerminalUI:
 
     def _select_boolean(self, title, default=False):
         default_choice = 'yes' if default else 'no'
-        choice = self._select_option(title, ['yes', 'no'], default_choice, 'Use Up/Down arrows and Enter to choose.')
+        choice = self._select_option(title, ['yes', 'no'], default_choice, 'Use Up/Down arrows and Enter to choose. Esc/Ctrl-C to cancel.')
         return choice == 'yes'
 
     def select_mode(self, default_mode='code'):
@@ -121,7 +121,7 @@ class TerminalUI:
         default_model = default_model or self.utility_manager.get_default_model_name()
         if default_model not in models:
             default_model = models[0]
-        return self._select_option('Model', models, default_model, 'Use Up/Down arrows, Enter, or type the first letter to jump.')
+        return self._select_option('Model', models, default_model, 'Use Up/Down arrows, Enter, or type the first letter to jump. Esc/Ctrl-C to cancel.')
 
     def select_language(self, default_lang='python'):
         return self._select_option('Language', ['python', 'javascript'], default_lang)


### PR DESCRIPTION
💡 What: Improved the TUI interactive selection menus by handling `Ctrl-C` (`\x03`) to correctly cancel selections, adding `choices` argument to fallback CLI prompts for visible options, and explicitly advertising cancellation shortcut hints (`Esc/Ctrl-C`) in the footer.
🎯 Why: Terminal applications that suppress standard interrupts (`Ctrl-C`) in raw mode without advertising alternative exit paths (like `Esc`) create frustrating "keyboard traps" where users feel stuck. Missing visible choices in fallback text prompts reduced discoverability. This change adds immediate micro-UX improvements to ensure users can clearly navigate and safely exit prompts.
📸 Before/After: 
  * Before: Text fallback prompts would ask "Model" but not list available options; `Ctrl-C` in raw TUI mode would do nothing.
  * After: Text fallback prompts list options (e.g. `Model [gpt-4o/claude-3]`); `Ctrl-C` smoothly exits TUI; Footer reads `Use Up/Down arrows and Enter to select. Esc/Ctrl-C to cancel.`
♿ Accessibility: Prevents a severe terminal keyboard trap (WCAG 2.1.2 No Keyboard Trap equivalent) by restoring standard system exit bindings (`Ctrl-C`) and providing clear instructional hints.

---
*PR created automatically by Jules for task [6858331542103829830](https://jules.google.com/task/6858331542103829830) started by @haseeb-heaven*