### PR TITLE
🎨 Palette: [UX improvement] Fix TUI keyboard trap and update shortcut hints

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-10 - TUI Keyboard Trap Resolution
+**Learning:** Raw terminal mode blocks standard interrupt signals (`` / Ctrl-C), which can inadvertently trap users in TUI menus if not explicitly handled alongside `escape`.
+**Action:** When implementing raw mode input capture for terminal UIs, always explicitly map the `` byte to an exit/cancel action and provide clear on-screen hints like '(Esc/Ctrl-C to cancel)' to prevent keyboard traps.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -25,7 +25,7 @@ class TerminalUI:
                 return mapping.get(extended, extended)
             if key == '\r':
                 return 'enter'
-            if key == '\x1b':
+            if key in ('\x1b', '\x03'):
                 return 'escape'
             return key
 
@@ -41,6 +41,8 @@ class TerminalUI:
                 next_chars = sys.stdin.read(2)
                 mapping = {'[A': 'up', '[B': 'down', '[D': 'left', '[C': 'right'}
                 return mapping.get(next_chars, 'escape')
+            if key == '\x03':
+                return 'escape'
             if key in ('\r', '\n'):
                 return 'enter'
             return key
@@ -67,7 +69,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = help_text or 'Use Up/Down arrows and Enter to select. (Esc/Ctrl-C to cancel)'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -110,7 +112,7 @@ class TerminalUI:
 
     def _select_boolean(self, title, default=False):
         default_choice = 'yes' if default else 'no'
-        choice = self._select_option(title, ['yes', 'no'], default_choice, 'Use Up/Down arrows and Enter to choose.')
+        choice = self._select_option(title, ['yes', 'no'], default_choice, 'Use Up/Down arrows and Enter to choose. (Esc/Ctrl-C to cancel)')
         return choice == 'yes'
 
     def select_mode(self, default_mode='code'):


### PR DESCRIPTION
💡 What:
Mapped the `\x03` (Ctrl-C) interrupt byte to trigger the `escape` action in the raw mode key handler and updated the UI footer to explicitly state `(Esc/Ctrl-C to cancel)`.

🎯 Why:
Users in the interactive TUI were getting stuck in the menu because standard Unix/Windows interrupt signals are blocked in terminal raw mode. This created a keyboard trap, leaving users confused about how to exit without force-closing the terminal.

📸 Before/After:
Before: `Use Up/Down arrows and Enter to select.`
After:  `Use Up/Down arrows and Enter to select. (Esc/Ctrl-C to cancel)`

♿ Accessibility:
Prevents a terminal keyboard trap and ensures standard, expected OS exit combinations function safely without disrupting the UI.

---
*PR created automatically by Jules for task [7465430666064206905](https://jules.google.com/task/7465430666064206905) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ctrl-C keyboard shortcut now functions as a cancellation action in interactive terminal selections, matching Escape key behavior across all systems.

* **Documentation**
  * Updated on-screen help text to explicitly indicate both Esc and Ctrl-C as available options for cancellation and exit actions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/code-interpreter/pull/30)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->