### PR TITLE
🎨 Palette: [Fix keyboard trap and improve TUI hints]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-10 - TUI Keyboard Traps and Shortcut Hints
+**Learning:** Terminal UIs using raw input mode can create keyboard traps if standard interrupt bytes like `\x03` (Ctrl-C) aren't explicitly handled to exit loops. Users stuck in these loops without clear visible shortcut hints (like "Esc/Ctrl-C to cancel") experience frustration. Additionally, fallback prompts for non-TTY environments must explicitly state their acceptable choices, otherwise it creates an inaccessible guessing game.
+**Action:** When creating raw TTY interactive loops, always map the `\x03` interrupt byte to a cancel/exit action, clearly document the shortcut keys in the UI footer, and provide explicit choices arrays to text-based prompt fallbacks.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -68,6 +68,7 @@ class TerminalUI:
             table.add_row(marker, label, style=style)
 
         footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer += ' (Esc/Ctrl-C to cancel)'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +77,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title}", choices=options, default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:
@@ -99,7 +100,7 @@ class TerminalUI:
                 selected_index = (selected_index + 1) % len(options)
             elif key == 'enter':
                 return options[selected_index]
-            elif key == 'escape':
+            elif key in ('escape', '\x03'):
                 raise KeyboardInterrupt('Selection cancelled by user.')
             elif isinstance(key, str) and len(key) == 1:
                 lowered = key.lower()


### PR DESCRIPTION
💡 What: Fixed a keyboard trap in the terminal UI where `Ctrl-C` (`\x03`) was ignored, added an explicit cancel hint (`Esc/Ctrl-C to cancel`) in the footer, and improved fallback prompts to display choices explicitly.

🎯 Why: Users stuck in raw mode loops without a clear exit method experience frustration. Providing visible shortcut hints and ensuring standard interrupt bytes work makes the TUI much more intuitive and accessible. Text-based fallback prompts also needed explicit choices to avoid a guessing game.

📸 Before/After:
Before: TUI footer just said "Use Up/Down arrows and Enter to select." and `Ctrl-C` did nothing. Fallback prompts looked like `Mode:` instead of `Mode [code/chat/script/command/vision]`.
After: TUI footer says "Use Up/Down arrows and Enter to select. (Esc/Ctrl-C to cancel)". `Ctrl-C` now correctly raises `KeyboardInterrupt`. Fallback prompts display choices clearly.

♿ Accessibility: Ensures keyboard users are not trapped in a loop and screen readers (if used in fallback mode) can announce explicit choice lists.

---
*PR created automatically by Jules for task [12893386644288190764](https://jules.google.com/task/12893386644288190764) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal selector UI now supports cancellation via Ctrl-C in addition to Esc key.

* **Bug Fixes**
  * Improved non-TTY mode input handling with proper option constraints.

* **Documentation**
  * Added UI guidance for terminal interactive loops covering interrupt handling, shortcut hints, and accessible non-TTY fallbacks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/code-interpreter/pull/32)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->