### PR TITLE
🎨 Palette: Add Ctrl-C handler to TUI and explicit shortcut hints

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-18 - TUI Keyboard Traps
+**Learning:** In terminal UI (TUI) environments, standard web-specific UX concepts need terminal equivalents. Using explicit prompt choices, clear shortcut hints ('Esc/Ctrl-C to cancel'), and mapping standard interrupt bytes (`\x03`) to exit actions in raw mode is essential to prevent keyboard traps.
+**Action:** When implementing terminal UIs with raw mode input, ensure standard interrupt bytes (`\x03`) are explicitly handled and mapped to an escape or exit action, and provide clear hints to the user.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -25,7 +25,7 @@ class TerminalUI:
                 return mapping.get(extended, extended)
             if key == '\r':
                 return 'enter'
-            if key == '\x1b':
+            if key in ('\x1b', '\x03'):
                 return 'escape'
             return key
 
@@ -43,6 +43,8 @@ class TerminalUI:
                 return mapping.get(next_chars, 'escape')
             if key in ('\r', '\n'):
                 return 'enter'
+            if key == '\x03':
+                return 'escape'
             return key
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
@@ -67,7 +69,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = help_text or 'Use Up/Down arrows and Enter to select. (Esc/Ctrl-C to cancel)'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -110,7 +112,7 @@ class TerminalUI:
 
     def _select_boolean(self, title, default=False):
         default_choice = 'yes' if default else 'no'
-        choice = self._select_option(title, ['yes', 'no'], default_choice, 'Use Up/Down arrows and Enter to choose.')
+        choice = self._select_option(title, ['yes', 'no'], default_choice, 'Use Up/Down arrows and Enter to choose. (Esc/Ctrl-C to cancel)')
         return choice == 'yes'
 
     def select_mode(self, default_mode='code'):


### PR DESCRIPTION
Mapped `\x03` to explicitly trigger an 'escape' cancellation in the TUI loop, preventing keyboard traps during terminal sessions. Also updated standard selector UI strings to make shortcut hints clear (e.g. `(Esc/Ctrl-C to cancel)`).

---
*PR created automatically by Jules for task [11793906659365264993](https://jules.google.com/task/11793906659365264993) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard handling to consistently recognize both Escape and Ctrl-C as cancel signals across all platforms
  * Enhanced on-screen help text with clearer cancellation instructions for better user guidance

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/code-interpreter/pull/36)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->