### PR TITLE
🎨 Palette: Fix terminal UI keyboard trap and add explicit shortcut hints

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-13 - Preventing Terminal Keyboard Traps
+**Learning:** In terminal raw-mode UI implementations (like `libs/terminal_ui.py`), standard shell interrupt signals (like Ctrl-C) are intercepted. If standard interrupt bytes (e.g., `\x03`) are not explicitly mapped to an exit action, users become trapped in the prompt.
+**Action:** Always map standard interrupt bytes (e.g., `\x03` for Ctrl-C) to an escape/exit action when implementing raw terminal input loops, and explicitly mention these shortcuts in the prompt's help text.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -25,7 +25,7 @@ class TerminalUI:
                 return mapping.get(extended, extended)
             if key == '\r':
                 return 'enter'
-            if key == '\x1b':
+            if key in ('\x1b', '\x03'):
                 return 'escape'
             return key
 
@@ -43,6 +43,8 @@ class TerminalUI:
                 return mapping.get(next_chars, 'escape')
             if key in ('\r', '\n'):
                 return 'enter'
+            if key == '\x03':
+                return 'escape'
             return key
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
@@ -67,7 +69,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = help_text or 'Use Up/Down arrows and Enter to select. Esc/Ctrl-C to cancel.'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -110,7 +112,10 @@ class TerminalUI:
 
     def _select_boolean(self, title, default=False):
         default_choice = 'yes' if default else 'no'
-        choice = self._select_option(title, ['yes', 'no'], default_choice, 'Use Up/Down arrows and Enter to choose.')
+        choice = self._select_option(
+            title, ['yes', 'no'], default_choice,
+            'Use Up/Down arrows and Enter to choose. Esc/Ctrl-C to cancel.'
+        )
         return choice == 'yes'
 
     def select_mode(self, default_mode='code'):
@@ -121,7 +126,10 @@ class TerminalUI:
         default_model = default_model or self.utility_manager.get_default_model_name()
         if default_model not in models:
             default_model = models[0]
-        return self._select_option('Model', models, default_model, 'Use Up/Down arrows, Enter, or type the first letter to jump.')
+        return self._select_option(
+            'Model', models, default_model,
+            'Use Up/Down arrows, Enter, or type the first letter to jump. Esc/Ctrl-C to cancel.'
+        )
 
     def select_language(self, default_lang='python'):
         return self._select_option('Language', ['python', 'javascript'], default_lang)
@@ -130,16 +138,20 @@ class TerminalUI:
         return self._select_boolean(title, default=default)
 
     def interactive_settings(self, interpreter):
-        current_model = getattr(interpreter, "INTERPRETER_MODEL_LABEL", None) or getattr(interpreter, "INTERPRETER_MODEL", None)
+        current_model = getattr(interpreter, "INTERPRETER_MODEL_LABEL", None) or getattr(
+            interpreter, "INTERPRETER_MODEL", None)
         current_mode = getattr(interpreter, "INTERPRETER_MODE", "code")
         current_lang = getattr(interpreter, "INTERPRETER_LANGUAGE", "python")
 
         mode = self.select_mode(current_mode)
         model = self.select_model(current_model)
         language = self.select_language(current_lang)
-        display_code = self.select_boolean('Display generated code automatically?', default=getattr(interpreter, "DISPLAY_CODE", False))
-        execute_code = self.select_boolean('Execute generated code automatically?', default=getattr(interpreter, "EXECUTE_CODE", False))
-        save_code = self.select_boolean('Save generated output automatically?', default=getattr(interpreter, "SAVE_CODE", False))
+        display_code = self.select_boolean(
+            'Display generated code automatically?', default=getattr(interpreter, "DISPLAY_CODE", False))
+        execute_code = self.select_boolean(
+            'Execute generated code automatically?', default=getattr(interpreter, "EXECUTE_CODE", False))
+        save_code = self.select_boolean(
+            'Save generated output automatically?', default=getattr(interpreter, "SAVE_CODE", False))
         history = self.select_boolean('Enable history memory?', default=getattr(interpreter, "INTERPRETER_HISTORY", False))
 
         return {


### PR DESCRIPTION
💡 What: Added explicit handling of the `\x03` (Ctrl-C) raw byte to map to the `escape` action in the Terminal UI, and updated footer help text to indicate "Esc/Ctrl-C to cancel."
🎯 Why: In raw-mode TUIs, standard shell interrupt signals are swallowed. Without explicit mapping, users could get trapped in the prompt when instinctively pressing Ctrl-C.
📸 Before/After: Visual help text changed from "Use Up/Down arrows and Enter to select." to "Use Up/Down arrows and Enter to select. Esc/Ctrl-C to cancel."
♿ Accessibility: Improves terminal keyboard navigation accessibility by providing a clear escape hatch and reducing cognitive load through explicit instructions.

---
*PR created automatically by Jules for task [11297352019074157105](https://jules.google.com/task/11297352019074157105) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ctrl-C now functions as an escape/cancel action in terminal-based selection interfaces. Help text has been updated to explicitly mention this keyboard shortcut alongside Escape.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/code-interpreter/pull/38)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->