### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path traversal in file reading

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-13 - Path Traversal in File Context Extraction
+**Vulnerability:** Path traversal in `libs/utility_manager.py`'s `get_full_file_path` allowed attackers to include arbitrary files (e.g., `../../etc/passwd`) by manipulating the prompt input used for context extraction. The file paths weren't correctly validated to be within the application's working directory.
+**Learning:** `os.path.join(os.getcwd(), path)` is unsafe when `path` contains `../`. Python's `os.path.join` does not normalize paths, and using `open` on the resulting string will traverse outside the base path.
+**Prevention:** Always use `os.path.abspath(os.path.join(cwd, file_name))` and assert that `full_path.startswith(os.path.abspath(cwd))` before operating on the path.

--- a/libs/utility_manager.py
+++ b/libs/utility_manager.py
@@ -186,10 +186,19 @@ class UtilityManager:
 		if not file_name:
 			return None
 
+		cwd = os.path.abspath(os.getcwd())
 		# Check if the file path is absolute. If not, prepend the current working directory
 		if not os.path.isabs(file_name):
-			return os.path.join(os.getcwd(), file_name)
-		return file_name
+			full_path = os.path.abspath(os.path.join(cwd, file_name))
+		else:
+			full_path = os.path.abspath(file_name)
+
+		# Security check: Ensure the path is within the current working directory
+		if not full_path.startswith(cwd):
+			self.logger.warning(f"Path traversal attempt blocked: {file_name}")
+			return None
+
+		return full_path
 	
 	def read_csv_headers(self, file_path):
 		try:


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Path traversal vulnerability when interpreting file inputs via the LLM prompt interface. The `UtilityManager.get_full_file_path()` used `os.path.join` natively without boundary checking relative jumps (`../`), meaning arbitrary absolute paths could be loaded as context, reading server files.
🎯 Impact: File exposure/information disclosure. Attackers can view sensitive credentials and system files inside the environment sandbox via the LLM's file parsing routines.
🔧 Fix: Resolved the full file path dynamically mapping `os.getcwd()` with the user's `file_name` string and ensuring via `startswith()` that the final resolved path stays within the working directory constraint.
✅ Verification: Ran testing module via `python3 -m unittest discover tests` to ensure no functionality is compromised and executed targeted testing resolving `../../etc/passwd` to verify the boundary constraint intercepts appropriately.

---
*PR created automatically by Jules for task [8821517670863300565](https://jules.google.com/task/8821517670863300565) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a path traversal security vulnerability. File path operations now validate that accessed files remain within the intended working directory, rejecting any attempts to access files outside this boundary.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/code-interpreter/pull/39)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->