### PR TITLE
🎨 Palette: Fix keyboard trap by mapping Ctrl-C to cancel on TUI selection

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+## 2024-05-14 - Handle Ctrl-C gracefully in TUI keyboard traps
+
+**Learning:** In terminal UI (TUI) environments like this repository, web-specific UX concepts translate to terminal equivalents such as avoiding keyboard traps by mapping standard interrupt bytes (`\x03`) to exit actions in raw mode.
+**Action:** Always intercept standard termination characters in raw input handling.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -25,7 +25,7 @@ class TerminalUI:
                 return mapping.get(extended, extended)
             if key == '\r':
                 return 'enter'
-            if key == '\x1b':
+            if key in ('\x1b', '\x03'):
                 return 'escape'
             return key
 
@@ -41,6 +41,8 @@ class TerminalUI:
                 next_chars = sys.stdin.read(2)
                 mapping = {'[A': 'up', '[B': 'down', '[D': 'left', '[C': 'right'}
                 return mapping.get(next_chars, 'escape')
+            if key == '\x03':
+                return 'escape'
             if key in ('\r', '\n'):
                 return 'enter'
             return key
@@ -67,7 +69,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = help_text or 'Use Up/Down arrows and Enter to select. Esc/Ctrl-C to cancel.'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)


### PR DESCRIPTION
💡 **What**: Mapped the `\x03` (Ctrl-C) byte in raw mode to the "escape" action in the `libs/terminal_ui.py` selection screen and updated the hint footer text from "Use Up/Down arrows and Enter to select." to "Use Up/Down arrows and Enter to select. Esc/Ctrl-C to cancel."
🎯 **Why**: When users enter the new TUI interactive selection screen, their normal SIGINT behaviors are hijacked by raw input modes (or msvcrt Windows key capture loops), causing a confusing "keyboard trap". This restores intuitive user experience and safely aborts without crashing terminal state.
📸 **Before/After**: N/A visual change in the prompt footer.
♿ **Accessibility**: Provides an escape hatch and explicitly documents the exit process for non-sighted users or those relying on screen-reader announcements of prompt footers.

---
*PR created automatically by Jules for task [17109577773328798216](https://jules.google.com/task/17109577773328798216) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ctrl-C can now be used to cancel selections in the terminal UI, providing an alternative to the Escape key across all platforms.

* **Documentation**
  * Added guidance on handling Ctrl-C interrupts gracefully within terminal user interfaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/code-interpreter/pull/40)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->