### PR TITLE
🎨 Palette: [UX improvement] Fix terminal UI keyboard trap

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Interactive TUI Keyboard Traps
+**Learning:** In raw terminal mode, standard interrupt bytes like `\x03` (Ctrl-C) and `\x04` (Ctrl-D) are captured rather than raising exceptions, trapping users in the interactive prompts unless explicitly handled.
+**Action:** Map standard interrupt characters to KeyboardInterrupt or exit sequences in all raw terminal inputs, and clearly label the cancellation shortcuts (like "Esc/Ctrl-C to cancel") on screen.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -67,7 +67,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = help_text or 'Use Up/Down arrows and Enter to select. Esc/Ctrl-C to cancel.'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -99,7 +99,7 @@ class TerminalUI:
                 selected_index = (selected_index + 1) % len(options)
             elif key == 'enter':
                 return options[selected_index]
-            elif key == 'escape':
+            elif key in ('escape', '\x03', '\x04'):
                 raise KeyboardInterrupt('Selection cancelled by user.')
             elif isinstance(key, str) and len(key) == 1:
                 lowered = key.lower()


### PR DESCRIPTION
Fixes terminal UI keyboard trap by ensuring `\x03` and `\x04` capture properly.

---
*PR created automatically by Jules for task [15234183845529568317](https://jules.google.com/task/15234183845529568317) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interactive selection menus now properly respond to Ctrl-C and Ctrl-D keyboard interrupts for cancellation, in addition to the Escape key.
  * Menu footer text updated to clearly inform users of available cancellation shortcuts (Esc/Ctrl-C).

* **Documentation**
  * Added entry documenting keyboard interrupt handling in raw terminal mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/code-interpreter/pull/43)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->