### PR TITLE
🎨 Palette: [UX improvement] Fix TUI keyboard trap and add shortcut hints

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-16 - Terminal Raw Mode Keyboard Traps
+**Learning:** In terminal UIs using raw mode (like via `tty.setraw()`), standard interrupt signals (like `\x03` for Ctrl-C) are not automatically processed by the OS to exit the program. If not explicitly handled in the key-reading logic, this creates a frustrating keyboard trap where users cannot cancel out of menus.
+**Action:** Always map standard interrupt bytes (e.g., `\x03` for Ctrl-C) to an explicit exit/cancel action (like `'escape'`) when implementing custom raw mode keyboard handlers in TUI components. Add explicit shortcut hints to the UI to make these cancel options clear.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -43,6 +43,8 @@ class TerminalUI:
                 return mapping.get(next_chars, 'escape')
             if key in ('\r', '\n'):
                 return 'enter'
+            if key == '\x03':
+                return 'escape'
             return key
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
@@ -67,7 +69,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = help_text or 'Use Up/Down arrows and Enter to select. Esc/Ctrl-C to cancel.'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -110,7 +112,8 @@ class TerminalUI:
 
     def _select_boolean(self, title, default=False):
         default_choice = 'yes' if default else 'no'
-        choice = self._select_option(title, ['yes', 'no'], default_choice, 'Use Up/Down arrows and Enter to choose.')
+        help_text = 'Use Up/Down arrows and Enter to choose. Esc/Ctrl-C to cancel.'
+        choice = self._select_option(title, ['yes', 'no'], default_choice, help_text)
         return choice == 'yes'
 
     def select_mode(self, default_mode='code'):
@@ -121,7 +124,8 @@ class TerminalUI:
         default_model = default_model or self.utility_manager.get_default_model_name()
         if default_model not in models:
             default_model = models[0]
-        return self._select_option('Model', models, default_model, 'Use Up/Down arrows, Enter, or type the first letter to jump.')
+        help_text = 'Use Up/Down arrows, Enter, or type first letter to jump. Esc/Ctrl-C to cancel.'
+        return self._select_option('Model', models, default_model, help_text)
 
     def select_language(self, default_lang='python'):
         return self._select_option('Language', ['python', 'javascript'], default_lang)
@@ -130,16 +134,20 @@ class TerminalUI:
         return self._select_boolean(title, default=default)
 
     def interactive_settings(self, interpreter):
-        current_model = getattr(interpreter, "INTERPRETER_MODEL_LABEL", None) or getattr(interpreter, "INTERPRETER_MODEL", None)
+        current_model = getattr(interpreter, "INTERPRETER_MODEL_LABEL", None) \
+            or getattr(interpreter, "INTERPRETER_MODEL", None)
         current_mode = getattr(interpreter, "INTERPRETER_MODE", "code")
         current_lang = getattr(interpreter, "INTERPRETER_LANGUAGE", "python")
 
         mode = self.select_mode(current_mode)
         model = self.select_model(current_model)
         language = self.select_language(current_lang)
-        display_code = self.select_boolean('Display generated code automatically?', default=getattr(interpreter, "DISPLAY_CODE", False))
-        execute_code = self.select_boolean('Execute generated code automatically?', default=getattr(interpreter, "EXECUTE_CODE", False))
-        save_code = self.select_boolean('Save generated output automatically?', default=getattr(interpreter, "SAVE_CODE", False))
+        display_code = self.select_boolean(
+            'Display generated code automatically?', default=getattr(interpreter, "DISPLAY_CODE", False))
+        execute_code = self.select_boolean(
+            'Execute generated code automatically?', default=getattr(interpreter, "EXECUTE_CODE", False))
+        save_code = self.select_boolean(
+            'Save generated output automatically?', default=getattr(interpreter, "SAVE_CODE", False))
         history = self.select_boolean('Enable history memory?', default=getattr(interpreter, "INTERPRETER_HISTORY", False))
 
         return {


### PR DESCRIPTION
### 💡 What: 
Added handling for `\x03` (Ctrl-C) in `_read_key()` to prevent users from getting stuck in raw terminal mode, and added explicit "Esc/Ctrl-C to cancel" shortcut hints to UI menus (`_render_selector`, etc.).

### 🎯 Why: 
In the Terminal UI's raw mode, standard interrupt signals are consumed instead of terminating the app natively. This left users permanently stuck in the selector loop unless they guessed 'Esc', creating a frustrating "keyboard trap". Adding the visual hint also teaches users how to escape gracefully.

### 📸 Before/After: 
**Before:** No visible cancel shortcut hints. Pressing Ctrl-C seemingly does nothing in the selector loops.
**After:** Hints like `Use Up/Down arrows and Enter to choose. Esc/Ctrl-C to cancel.` appear. Pressing Ctrl-C safely exits the prompt flow.

### ♿ Accessibility:
Fixed a critical keyboard trap issue where users could lose their ability to interact with the system or break out of navigation loops via standard expected terminal shortcuts (Ctrl-C). Adding text labels for shortcuts also improves general interface clarity and navigability.

---
*PR created automatically by Jules for task [10215318234489665712](https://jules.google.com/task/10215318234489665712) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ctrl-C now properly cancels terminal selections instead of being ignored
  * Help text across interactive prompts now explicitly indicates available keyboard shortcuts for cancellation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/code-interpreter/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->