### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in file download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-30 - Path Traversal bypass with absolute paths
+**Vulnerability:** Path Traversal via absolute paths bypassing relative check
+**Learning:** Checking `if not os.path.isabs(file_name)` to selectively enforce traversal checks leaves the application vulnerable to direct absolute path access (e.g. `/etc/passwd`). Furthermore, failing open on `commonpath` exceptions like `ValueError` (which occurs for different drives on Windows) could inadvertently permit traversal.
+**Prevention:** Always normalize user-provided paths (whether relative or absolute) to an absolute path using `os.path.abspath`, then enforce a strict boundary constraint (e.g. `os.path.commonpath([cwd, full_path]) == cwd`) to ensure the resultant path resides within the intended directory. Fail securely by blocking access on any `ValueError`.

--- a/libs/utility_manager.py
+++ b/libs/utility_manager.py
@@ -186,10 +186,26 @@ class UtilityManager:
 		if not file_name:
 			return None
 
-		# Check if the file path is absolute. If not, prepend the current working directory
+		cwd = os.getcwd()
+
+		# Resolve the path to an absolute path, whether it was relative or absolute
 		if not os.path.isabs(file_name):
-			return os.path.join(os.getcwd(), file_name)
-		return file_name
+			full_path = os.path.abspath(os.path.join(cwd, file_name))
+		else:
+			full_path = os.path.abspath(file_name)
+
+		# Enforce that the resolved path is within the current working directory
+		try:
+			if os.path.commonpath([cwd, full_path]) != cwd:
+				raise ValueError(f"Path traversal detected: {file_name}")
+		except ValueError as e:
+			if "Path traversal detected" in str(e):
+				raise
+			# If commonpath raises ValueError (e.g., paths on different drives on Windows),
+			# it definitively means full_path is outside of cwd. We must block it.
+			raise ValueError(f"Path traversal detected (different drive): {file_name}")
+
+		return full_path
 	
 	def read_csv_headers(self, file_path):
 		try:


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Path traversal vulnerability in `libs/utility_manager.py` allowed users to bypass security boundaries by supplying either relative paths (e.g., `../../etc/passwd`) or arbitrary absolute paths (e.g., `/etc/passwd`). The old logic only validated relative paths partially and allowed absolute paths to pass through directly.
🎯 Impact: An attacker could read or access arbitrary files on the host filesystem that the application process has permissions for, leading to sensitive data exposure or further compromise.
🔧 Fix: Updated `get_full_file_path` to convert all input paths (relative or absolute) to absolute paths via `os.path.abspath()`. Then, `os.path.commonpath()` is used to enforce a strict boundary check, ensuring the resolved path starts with the current working directory (`cwd`). If a traversal is attempted, a `ValueError` is raised safely.
✅ Verification: Ran unit tests to verify valid file resolutions still succeed, while paths like `../../etc/passwd` and `/etc/passwd` correctly throw `ValueError` errors as verified by manual manual testing and regression test suite.

---
*PR created automatically by Jules for task [962681918932203017](https://jules.google.com/task/962681918932203017) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced path traversal protection to enforce stricter validation and prevent unauthorized file access outside the working directory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/code-interpreter/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->