### PR TITLE
🎨 Palette: [UX improvement] Fix keyboard trap and add shortcut hints

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-18 - Prevent Keyboard Traps in Terminal Raw Mode
+**Learning:** Raw terminal UI modes intercept system-level signals like Ctrl-C (`\x03`), causing unexpected keyboard traps if not explicitly handled as interrupt/escape actions. Additionally, terminal users lack visual UI affordances and rely on discoverability, making explicit shortcut hints essential for intuitive navigation.
+**Action:** Always map standard terminal interrupt bytes (`\x03`) to escape/cancel actions when using raw input (`tty.setraw` or `msvcrt`), and explicitly document the exit shortcuts in UI footers.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -25,7 +25,7 @@ class TerminalUI:
                 return mapping.get(extended, extended)
             if key == '\r':
                 return 'enter'
-            if key == '\x1b':
+            if key in ('\x1b', '\x03'):
                 return 'escape'
             return key
 
@@ -41,6 +41,8 @@ class TerminalUI:
                 next_chars = sys.stdin.read(2)
                 mapping = {'[A': 'up', '[B': 'down', '[D': 'left', '[C': 'right'}
                 return mapping.get(next_chars, 'escape')
+            if key == '\x03':
+                return 'escape'
             if key in ('\r', '\n'):
                 return 'enter'
             return key
@@ -67,7 +69,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = help_text or 'Use Up/Down arrows and Enter to select. Esc/Ctrl-C to cancel.'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -110,7 +112,7 @@ class TerminalUI:
 
     def _select_boolean(self, title, default=False):
         default_choice = 'yes' if default else 'no'
-        choice = self._select_option(title, ['yes', 'no'], default_choice, 'Use Up/Down arrows and Enter to choose.')
+        choice = self._select_option(title, ['yes', 'no'], default_choice, 'Use Up/Down arrows and Enter to choose. Esc/Ctrl-C to cancel.')
         return choice == 'yes'
 
     def select_mode(self, default_mode='code'):
@@ -121,7 +123,7 @@ class TerminalUI:
         default_model = default_model or self.utility_manager.get_default_model_name()
         if default_model not in models:
             default_model = models[0]
-        return self._select_option('Model', models, default_model, 'Use Up/Down arrows, Enter, or type the first letter to jump.')
+        return self._select_option('Model', models, default_model, 'Use Up/Down arrows, Enter, or type the first letter to jump. Esc/Ctrl-C to cancel.')
 
     def select_language(self, default_lang='python'):
         return self._select_option('Language', ['python', 'javascript'], default_lang)


### PR DESCRIPTION
💡 **What**:
- Mapped the raw `\x03` byte (Ctrl-C) to the `escape` fallback inside `TerminalUI._read_key()` for both `msvcrt` (Windows) and `tty`/`termios` (Unix).
- Added explicit "Esc/Ctrl-C to cancel." instructions to the footer text of all Terminal UI selectors (mode, model, and boolean inputs).
- Logged the UX learning regarding raw mode input traps to `.Jules/palette.md`.

🎯 **Why**:
- Previously, running `interpreter.py --tui` placed the terminal in raw input mode to capture arrow keys. However, standard system signals like `SIGINT` (`Ctrl-C`) were trapped and printed raw bytes, forcing users to discover `Esc` or violently kill the process.
- Terminal interfaces lack visual affordances (like a back button). Explicit string hints increase discoverability and confidence for command-line users.

📸 **Before/After**:
- *Before*: `Use Up/Down arrows and Enter to select.`
- *After*: `Use Up/Down arrows and Enter to select. Esc/Ctrl-C to cancel.`
- *Before*: Pressing `Ctrl-C` did nothing or produced unexpected characters.
- *After*: Pressing `Ctrl-C` cleanly raises the `KeyboardInterrupt('Selection cancelled by user.')` and exits the prompt.

♿ **Accessibility**:
- Prevents the classic "keyboard trap" violation where a user is unable to exit a specific mode using standard operating system navigation (like Ctrl-C).
- Improves cognitive accessibility by explicitly documenting available interactions rather than relying on assumed terminal knowledge.

---
*PR created automatically by Jules for task [16595748202535740410](https://jules.google.com/task/16595748202535740410) started by @haseeb-heaven*