### PR TITLE
🎨 Palette: [UX improvement] Improve terminal UI keyboard trap and prompts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-19 - Terminal UI Micro-UX Improvements
+**Learning:** Web UX concepts like explicitly displaying available choices to the user and preventing keyboard traps translate directly to TUI environments. Users in headless/non-tty modes need visible prompt choices (via `rich.prompt.Prompt.ask(..., choices=...)`), and raw interactive modes must map interrupt bytes like `\x03` (Ctrl-C) to exit/cancel actions to prevent users from getting stuck.
+**Action:** Always verify that TUI components provide clear choice lists in fallback modes and map standard terminal interrupt signals safely when reading raw byte inputs.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -25,7 +25,7 @@ class TerminalUI:
                 return mapping.get(extended, extended)
             if key == '\r':
                 return 'enter'
-            if key == '\x1b':
+            if key in ('\x1b', '\x03'):
                 return 'escape'
             return key
 
@@ -43,6 +43,8 @@ class TerminalUI:
                 return mapping.get(next_chars, 'escape')
             if key in ('\r', '\n'):
                 return 'enter'
+            if key == '\x03':
+                return 'escape'
             return key
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
@@ -68,6 +70,7 @@ class TerminalUI:
             table.add_row(marker, label, style=style)
 
         footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer += ' (Esc/Ctrl-C to cancel)'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +79,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title}", choices=options, default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:

--- a/tests/test_terminal_ui.py
+++ b/tests/test_terminal_ui.py
@@ -1,0 +1,6 @@
+import pytest
+from libs.terminal_ui import TerminalUI
+
+def test_tui_init():
+    tui = TerminalUI()
+    assert tui is not None


### PR DESCRIPTION
💡 **What:** 
- Mapped `Ctrl-C` (`\x03`) to the escape action to prevent keyboard traps in raw TUI mode.
- Passed explicitly parsed valid choices to `rich.prompt.Prompt.ask` to make choices visible and selectable in headless environments.
- Appended explicit visual helpers `(Esc/Ctrl-C to cancel)` to TUI footers to inform users.

🎯 **Why:** 
Terminal UI loops without graceful interrupt handles trap users when typical OS bindings (like SIGINT to exit) are disabled. Displaying available prompt choices in a non-TTY terminal reduces confusion on valid inputs, ensuring smoother navigation inside the CLI experience.

📸 **Before/After:**
*Before:*
- Ctrl-C trapped users until arbitrary error or forcefully closed.
- Text interface: `Mode (code): `
- UI footer: `Use Up/Down arrows and Enter to select.`

*After:*
- Ctrl-C properly exits the TUI prompt dialogs.
- Text interface: `Mode [code/chat/script/command/vision] (code): `
- UI footer: `Use Up/Down arrows and Enter to select. (Esc/Ctrl-C to cancel)`

♿ **Accessibility:** 
Keyboard navigation heavily improved by providing explicitly defined ways to escape interactions instead of trapping users. Screenreader/fallback usage improved by explicitly exposing available valid options upfront.

---
*PR created automatically by Jules for task [12628117855406317302](https://jules.google.com/task/12628117855406317302) started by @haseeb-heaven*