### PR TITLE
🎨 Palette: [UX improvement] Clarify TUI choices and prevent keyboard traps

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2025-01-23 - Prevent keyboard traps and clarify choices in TUI
+**Learning:** In terminal UI environments, web-specific UX concepts translate to explicit prompt choices, clear shortcut hints ('Esc/Ctrl-C to cancel'), and avoiding keyboard traps by mapping standard interrupt bytes (`\x03`) to exit actions.
+**Action:** Always map `\x03` to an exit action in raw mode, explicitly list valid input choices in prompt strings, and clearly communicate cancellation shortcuts to users.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -25,7 +25,7 @@ class TerminalUI:
                 return mapping.get(extended, extended)
             if key == '\r':
                 return 'enter'
-            if key == '\x1b':
+            if key in ('\x1b', '\x03'):
                 return 'escape'
             return key
 
@@ -37,6 +37,8 @@ class TerminalUI:
         try:
             tty.setraw(fd)
             key = sys.stdin.read(1)
+            if key == '\x03':
+                return 'escape'
             if key == '\x1b':
                 next_chars = sys.stdin.read(2)
                 mapping = {'[A': 'up', '[B': 'down', '[D': 'left', '[C': 'right'}
@@ -67,7 +69,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = help_text or 'Use Up/Down arrows and Enter to select. Esc/Ctrl-C to cancel.'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +78,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} [{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:
@@ -110,7 +112,7 @@ class TerminalUI:
 
     def _select_boolean(self, title, default=False):
         default_choice = 'yes' if default else 'no'
-        choice = self._select_option(title, ['yes', 'no'], default_choice, 'Use Up/Down arrows and Enter to choose.')
+        choice = self._select_option(title, ['yes', 'no'], default_choice, 'Use Up/Down arrows and Enter to choose. Esc/Ctrl-C to cancel.')
         return choice == 'yes'
 
     def select_mode(self, default_mode='code'):
@@ -121,7 +123,7 @@ class TerminalUI:
         default_model = default_model or self.utility_manager.get_default_model_name()
         if default_model not in models:
             default_model = models[0]
-        return self._select_option('Model', models, default_model, 'Use Up/Down arrows, Enter, or type the first letter to jump.')
+        return self._select_option('Model', models, default_model, 'Use Up/Down arrows, Enter, or type the first letter to jump. Esc/Ctrl-C to cancel.')
 
     def select_language(self, default_lang='python'):
         return self._select_option('Language', ['python', 'javascript'], default_lang)


### PR DESCRIPTION
💡 What: Mapped `\x03` (Ctrl-C) to an escape action in raw mode, explicitly formatted choices in fallback prompt strings, and added 'Esc/Ctrl-C to cancel' shortcut hints to the UI footers.
🎯 Why: Raw terminal mode blocks standard `SIGINT` generation, meaning users hitting Ctrl-C were experiencing keyboard traps. Clarifying options and cancellation shortcuts reduces user confusion.
📸 Before/After: Visual hints added, input prompt format improved `Test Title [opt1|opt2]`.
♿ Accessibility: Reduces keyboard traps (WCAG 2.1.2) and adds explicit instructions for custom UI components (WCAG 3.3.2).

---
*PR created automatically by Jules for task [6579224844347118747](https://jules.google.com/task/6579224844347118747) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed keyboard trap issues in the terminal UI by ensuring Ctrl-C and Esc work consistently as cancellation options across all platforms.

* **Improvements**
  * Enhanced UI help text to explicitly display how to cancel (Esc/Ctrl-C).
  * Improved selection prompts to show valid options more clearly.

* **Documentation**
  * Updated guidance on preventing keyboard traps in terminal interfaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/code-interpreter/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->