### PR TITLE
🎨 Palette: [UX improvement] Fix TUI keyboard trap and improve prompt clarity

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Prevent TUI Keyboard Traps and Improve Headless Prompts
+**Learning:** TUI raw mode environments map standard OS interrupts like Ctrl-C (`\x03`) to literal bytes, creating keyboard traps if not handled. Also, headless terminal prompts can hide available choices if not explicitly rendered, and relying on `Prompt.ask(choices=...)` enforces strict matching which breaks custom case-insensitivity logic.
+**Action:** Always map `\x03` to `KeyboardInterrupt` alongside Escape, explicitly document cancellation shortcuts in UI panels, and manually interpolate choices into prompt strings (`[{'|'.join(options)}]`) to retain custom validation flexibility while guiding users.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -67,7 +67,8 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        base_footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = f"{base_footer} Esc/Ctrl-C to cancel."
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +77,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} [{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:
@@ -99,7 +100,7 @@ class TerminalUI:
                 selected_index = (selected_index + 1) % len(options)
             elif key == 'enter':
                 return options[selected_index]
-            elif key == 'escape':
+            elif key in ('escape', '\x03'):
                 raise KeyboardInterrupt('Selection cancelled by user.')
             elif isinstance(key, str) and len(key) == 1:
                 lowered = key.lower()


### PR DESCRIPTION
💡 What: Mapped `\x03` (Ctrl-C) to trigger a `KeyboardInterrupt` in the raw mode event loop. Added `Esc/Ctrl-C to cancel.` hints in the UI selector footer. Interpolated options manually into the `Prompt.ask` title so choices are visible headlessly.
🎯 Why: Without explicit handling in raw terminal modes, Ctrl-C becomes a literal byte leading to a keyboard trap where users cannot easily exit the app. Headless prompt setups previously lacked visibility of the available choices without breaking the underlying case-insensitive validation logic. 
📸 Before/After: Before, hitting Ctrl-C during prompts typed weird characters. Now, it reliably exits. Before, prompts like "Mode" had hidden choices. Now they say "Mode [code|chat|script|command|vision]".
♿ Accessibility: Adding explicit shortcut instructions (Esc/Ctrl-C) reduces friction and clarifies exit paths for keyboard navigation.

---
*PR created automatically by Jules for task [1350788730503491863](https://jules.google.com/task/1350788730503491863) started by @haseeb-heaven*