### PR TITLE
🎨 Palette: [UX improvement] Show choices in non-interactive prompts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Improve non-interactive prompt UX
+**Learning:** When using `rich` library's `Prompt.ask()` in a non-interactive (non-TTY) environment, providing the `choices` argument enforces strict case-sensitive input matching, breaking our custom case-insensitive fallback logic.
+**Action:** To provide clear UX by showing options to the user without breaking existing case-insensitivity, manually format the choices into the prompt string using an escaped bracket (e.g., `f"{title} \\[{'|'.join(options)}]"`) instead of passing the `choices` argument.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -76,7 +76,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
### 💡 What
Updated the fallback non-interactive prompt in `TerminalUI._select_option` to display available choices directly in the prompt string.

### 🎯 Why
When `Prompt.ask()` from the `rich` library is used without `choices`, users in non-interactive (headless) terminals do not know what options are valid. Adding `choices` directly enforces case-sensitivity, which breaks existing logic. By manually appending the options to the prompt string, we provide a clear UX cue while keeping the logic case-insensitive.

### 📸 Before/After
**Before:** `Mode:`
**After:** `Mode [code|chat|script|command|vision]:`

### ♿ Accessibility
Improves standard terminal UX by communicating valid system states explicitly to the user without hidden options.

---
*PR created automatically by Jules for task [1668052690611695064](https://jules.google.com/task/1668052690611695064) started by @haseeb-heaven*