### PR TITLE
🎨 Palette: Add explicit TUI choices, keyboard hints, and prevent Ctrl-C trap

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-25 - Terminal UI Keyboard Traps and Explicit Prompts
+**Learning:** Web-specific UX concepts like clear affordances and avoiding keyboard traps translate directly to TUI design. Using explicit prompt choices (via `rich` Prompt.ask), displaying clear shortcut hints ('Esc/Ctrl-C to cancel'), and manually handling interrupt bytes (`\x03`) in raw mode are critical to ensure accessibility and prevent users from getting stuck.
+**Action:** Always visually surface available options in headless/fallback prompts and ensure standard interrupt signals (`\x03`) are explicitly mapped to exit actions when operating in raw TTY mode.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -67,7 +67,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = help_text or 'Use Up/Down arrows and Enter to select. (Esc/Ctrl-C to cancel)'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +76,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:
@@ -99,7 +99,7 @@ class TerminalUI:
                 selected_index = (selected_index + 1) % len(options)
             elif key == 'enter':
                 return options[selected_index]
-            elif key == 'escape':
+            elif key in ('escape', '\x03'):
                 raise KeyboardInterrupt('Selection cancelled by user.')
             elif isinstance(key, str) and len(key) == 1:
                 lowered = key.lower()


### PR DESCRIPTION
💡 **What:**
- Added inline formatted choices to the non-interactive TUI fallback prompt using `rich` `Prompt.ask`.
- Added explicit cancellation shortcut hints (`Esc/Ctrl-C to cancel`) to the TUI selection footer.
- Handled the `\x03` raw byte alongside `escape` in the main TUI loop to prevent terminal keyboard traps during raw `tty` mode.

🎯 **Why:**
Users interacting with the fallback prompt didn't know what options were available (e.g., `Mode []`). In raw mode, standard `KeyboardInterrupt` (`Ctrl-C`) is trapped as the literal byte `\x03`, breaking expected terminal exit UX and causing users to get stuck.

📸 **Before/After:**
*Before (Headless):* `Mode []`
*After (Headless):* `Mode \[code|chat|script|command|vision]`

*Before (Footer):* `Use Up/Down arrows and Enter to select.`
*After (Footer):* `Use Up/Down arrows and Enter to select. (Esc/Ctrl-C to cancel)`

♿ **Accessibility:**
- Clear visual affordances for available input choices in non-visual modes.
- Prevention of keyboard traps in raw interactive mode (ensuring standard escape hatches like `Ctrl-C` map correctly to cancellation).

---
*PR created automatically by Jules for task [12308750234318381637](https://jules.google.com/task/12308750234318381637) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal UI selection prompts now consistently display cancellation instructions to guide users
  * Ctrl-C is now properly recognized and handled as a valid cancellation command
  * Selection prompts now display available options inline to enhance usability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/code-interpreter/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->