### PR TITLE
🎨 Palette: [UX improvement] Add clear shortcut hints and fix TUI keyboard trap

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Handle Ctrl-C in Raw Terminal Modes
+**Learning:** Raw terminal modes (via `tty.setraw()`) trap standard interrupts like Ctrl-C (`\x03`), causing users to become trapped in infinite input loops if not explicitly handled.
+**Action:** Always map the interrupt byte (`\x03`) to the standard exit action (e.g., 'escape' or cancelling) when reading raw keyboard input.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -25,7 +25,7 @@ class TerminalUI:
                 return mapping.get(extended, extended)
             if key == '\r':
                 return 'enter'
-            if key == '\x1b':
+            if key in ('\x1b', '\x03'):
                 return 'escape'
             return key
 
@@ -43,6 +43,8 @@ class TerminalUI:
                 return mapping.get(next_chars, 'escape')
             if key in ('\r', '\n'):
                 return 'enter'
+            if key == '\x03':
+                return 'escape'
             return key
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
@@ -68,6 +70,7 @@ class TerminalUI:
             table.add_row(marker, label, style=style)
 
         footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer += ' (Esc/Ctrl-C to cancel)'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +79,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
**💡 What:** 
- Updated `_read_key` in `libs/terminal_ui.py` to map the standard interrupt byte (`\x03`) to `escape` in both Windows and POSIX environments.
- Added a clear footer hint `(Esc/Ctrl-C to cancel)` to the interactive selection menus.
- Enhanced the `Prompt.ask` call in `_select_option` to manually display `[choices]` safely escaped in non-interactive modes.

**🎯 Why:** 
- When entering terminal raw mode using `tty.setraw()`, standard OS interrupts like Ctrl-C (`\x03`) are captured as raw characters rather than raising `KeyboardInterrupt`. Without mapping this explicitly, users could become endlessly trapped in TUI selection menus with no obvious way to exit.
- Providing visual shortcut hints improves discoverability of exit paths without needing to read documentation.

**📸 Before/After:**
*Before:*
- Ctrl-C during mode selection does nothing, creating a keyboard trap.
- Footer: `Use Up/Down arrows and Enter to select.`
- Non-interactive Prompt: `Mode (code):`

*After:*
- Ctrl-C cleanly cancels selection and exits the loop via `escape` mapping.
- Footer: `Use Up/Down arrows and Enter to select. (Esc/Ctrl-C to cancel)`
- Non-interactive Prompt: `Mode [code|chat|script|command|vision] (code):`

**♿ Accessibility:**
- Resolved a critical TUI keyboard trap (WCAG 2.1.2 No Keyboard Trap equivalent).
- Improved non-interactive TUI affordances by exposing explicit choices without compromising existing case-insensitivity logic.

---
*PR created automatically by Jules for task [1963817367718085320](https://jules.google.com/task/1963817367718085320) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ctrl-C now functions as a cancel/escape key on all platforms, providing an alternative to the Escape key
  * Help text updated to clarify cancellation options (Esc/Ctrl-C)
  * Prompts in non-TTY mode now explicitly display available options (e.g., [a|b|c])

* **Documentation**
  * Added guidance on raw terminal mode input and interrupt key handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/code-interpreter/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->