### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in resource opener

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-24 - Windows Shell Invocation Vulnerability
+**Vulnerability:** Invoking shell=True with subprocess on Windows to open files (e.g., `subprocess.call(['start', filename], shell=True)`) creates a command injection risk if `filename` contains unvalidated input.
+**Learning:** Windows platforms offer native `os.startfile()` which is immune to this specific shell injection attack vector.
+**Prevention:** Always prefer `os.startfile(filename)` over `subprocess.call(..., shell=True)` for opening files on Windows.

--- a/libs/utility_manager.py
+++ b/libs/utility_manager.py
@@ -43,7 +43,7 @@ class UtilityManager:
 		try:
 			if os.path.isfile(filename):
 				if platform.system() == "Windows":
-					subprocess.call(['start', filename], shell=True)
+					os.startfile(filename)
 				elif platform.system() == "Darwin":
 					subprocess.call(['open', filename])
 				elif platform.system() == "Linux":


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: When running on Windows, `UtilityManager._open_resource_file` was using `subprocess.call(['start', filename], shell=True)`. If `filename` could be controlled by user input and contained unvalidated shell meta-characters, this exposed the system to command injection.
🎯 Impact: An attacker could potentially execute arbitrary shell commands on a user's machine by passing specially crafted filenames to `_open_resource_file`.
🔧 Fix: Replaced `subprocess.call(['start', filename], shell=True)` with the native, safe `os.startfile(filename)`, which natively opens files without invoking an intermediate shell.
✅ Verification: Tested the file opening mechanism and confirmed the issue is fixed. Ran the complete test suite.

---
*PR created automatically by Jules for task [10161385641022155970](https://jules.google.com/task/10161385641022155970) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security in file opening mechanism on Windows to prevent potential command-injection vulnerabilities.

* **Documentation**
  * Added security guidance documentation for safe file handling practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/code-interpreter/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->