### PR TITLE
🎨 Palette: [UX improvement] Explicit Choices and Terminal Keyboard Traps

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-27 - Translating Web UX to Terminal
+**Learning:** Web-specific UX concepts (like explicit affordances and keyboard traps) translate directly to terminal UI: show choices explicitly in prompts, provide clear shortcut hints, and map interrupt bytes (`\x03`) to cancel/exit to prevent trapping users in raw mode.
+**Action:** Always add `\\[{'|'.join(options)}]` to rich prompts, add "Esc/Ctrl-C to cancel" hints to selector footers, and ensure raw mode reads explicitly catch `\x03`.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -25,6 +25,8 @@ class TerminalUI:
                 return mapping.get(extended, extended)
             if key == '\r':
                 return 'enter'
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
             if key == '\x1b':
                 return 'escape'
             return key
@@ -43,6 +45,8 @@ class TerminalUI:
                 return mapping.get(next_chars, 'escape')
             if key in ('\r', '\n'):
                 return 'enter'
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
             return key
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
@@ -67,7 +71,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = help_text or 'Use Up/Down arrows and Enter to select. Esc/Ctrl-C to cancel.'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +80,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
💡 What: The UX enhancement added:
  1. Handled `\x03` (Ctrl-C) mapping to `KeyboardInterrupt` in raw input modes for TUI options.
  2. Formatted fallback prompts (when stdin is not a TTY) so they show inline options.
  3. Added an explicit hint 'Esc/Ctrl-C to cancel.' in the selector footer.

🎯 Why: The user problem it solves:
  Keyboard trapping is a common CLI pitfall. If users pressed `Ctrl-C` during terminal option selection in a raw mode, they would get trapped. It was also unclear what options were valid when run non-interactively without TTY.

📸 Before/After: Visual changes:
  - Before: `Mode (code):` (in non-interactive).
  - After: `Mode \[code|chat|script|command|vision] (code):`
  - Footer before: `Use Up/Down arrows and Enter to select.`
  - Footer after: `Use Up/Down arrows and Enter to select. Esc/Ctrl-C to cancel.`

♿ Accessibility:
  Improved affordances for screen reader users on prompt inputs by explicitly providing options. Handled expected `Ctrl-C` interrupt safely out of raw mode to avoid terminal lockups.

---
*PR created automatically by Jules for task [2809483735457462282](https://jules.google.com/task/2809483735457462282) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidelines for translating web UX patterns to terminal interfaces.

* **Bug Fixes**
  * Improved Ctrl-C and Esc key handling to reliably cancel operations and prevent input traps.
  * Enhanced option presentation in non-interactive mode to display available choices inline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/code-interpreter/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->