### PR TITLE
🎨 Palette: [UX improvement] Fix keyboard trap and add explicit cancel hints in TUI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-28 - Avoid keyboard traps in TUI raw mode
+**Learning:** In terminal UIs using raw mode, standard interrupts like Ctrl-C (`\x03`) do not trigger `KeyboardInterrupt` automatically, creating a keyboard trap.
+**Action:** Always map standard interrupt bytes (e.g., `\x03`) to exit/cancel actions and explicitly document shortcuts like 'Esc/Ctrl-C to cancel' to improve accessibility.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -25,7 +25,7 @@ class TerminalUI:
                 return mapping.get(extended, extended)
             if key == '\r':
                 return 'enter'
-            if key == '\x1b':
+            if key in ('\x1b', '\x03'):
                 return 'escape'
             return key
 
@@ -43,6 +43,8 @@ class TerminalUI:
                 return mapping.get(next_chars, 'escape')
             if key in ('\r', '\n'):
                 return 'enter'
+            if key == '\x03':
+                return 'escape'
             return key
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
@@ -67,7 +69,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = help_text or 'Use Up/Down arrows and Enter to select. Esc/Ctrl-C to cancel.'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -110,7 +112,7 @@ class TerminalUI:
 
     def _select_boolean(self, title, default=False):
         default_choice = 'yes' if default else 'no'
-        choice = self._select_option(title, ['yes', 'no'], default_choice, 'Use Up/Down arrows and Enter to choose.')
+        choice = self._select_option(title, ['yes', 'no'], default_choice, 'Use Up/Down arrows and Enter to choose. Esc/Ctrl-C to cancel.')
         return choice == 'yes'
 
     def select_mode(self, default_mode='code'):
@@ -121,7 +123,7 @@ class TerminalUI:
         default_model = default_model or self.utility_manager.get_default_model_name()
         if default_model not in models:
             default_model = models[0]
-        return self._select_option('Model', models, default_model, 'Use Up/Down arrows, Enter, or type the first letter to jump.')
+        return self._select_option('Model', models, default_model, 'Use Up/Down arrows, Enter, or type the first letter to jump. Esc/Ctrl-C to cancel.')
 
     def select_language(self, default_lang='python'):
         return self._select_option('Language', ['python', 'javascript'], default_lang)


### PR DESCRIPTION
💡 What: Mapped `\x03` (Ctrl-C) to trigger an 'escape' action in raw TUI mode and added explicit "Esc/Ctrl-C to cancel" hints to menu prompts.
🎯 Why: Standard interrupt bytes like Ctrl-C (`\x03`) do not trigger standard `KeyboardInterrupt` actions when the terminal is in raw mode, effectively creating a keyboard trap where users cannot easily exit menus unless they happen to guess standard TUI exit keys like `Esc`. Adding the explicit text guides users intuitively.
📸 Before/After: 
- Before: Hitting `Ctrl-C` did nothing; Help text read "Use Up/Down arrows and Enter to select."
- After: Hitting `Ctrl-C` cleanly cancels out; Help text reads "Use Up/Down arrows and Enter to select. Esc/Ctrl-C to cancel."
♿ Accessibility: Fixes a critical keyboard trap issue for terminal TUI users and provides explicit visual hints for keyboard-only navigation.

---
*PR created automatically by Jules for task [11280687995720725239](https://jules.google.com/task/11280687995720725239) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a terminal UI keyboard trap issue preventing proper Ctrl-C handling
  * Ctrl-C now correctly functions as a cancel/exit action in dialogs across all platforms

* **Documentation**
  * Updated help text in selection dialogs to indicate "Esc/Ctrl-C to cancel" keyboard shortcuts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/code-interpreter/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->