### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix shell=True vulnerability on Windows

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Remove shell=True Vulnerabilities
+**Vulnerability:** Use of `shell=True` with `subprocess.call` and `subprocess.check_call` for commands like `start` on Windows, creating command injection risks.
+**Learning:** Even with argument validation, using `shell=True` on Windows allows the underlying command processor (`cmd.exe`) to interpret shell metacharacters, potentially leading to command injection.
+**Prevention:** Avoid `shell=True` entirely. Use `os.startfile(filename)` for opening files on Windows, and resolve executables using `shutil.which` to safely execute them without shell resolution.

--- a/libs/package_manager.py
+++ b/libs/package_manager.py
@@ -19,14 +19,20 @@ class PackageManager:
 		"""Run a shell command safely with OS-aware handling."""
 		try:
 			if os.name == 'nt':
-				# Windows requires shell=True for .cmd/.bat resolution
-				safe_pattern = re.compile(r'^[a-zA-Z0-9._\-\[\]=<>!,@]+$')
+				args = list(args)
+				safe_pattern = re.compile(r'^[a-zA-Z0-9._\-\[\]=<>!,\/\\@:]+$')
 				for arg in args:
 					if not isinstance(arg, str) or not safe_pattern.match(arg):
 						raise ValueError(f"Unsafe command argument: {arg}")
-				# Convert args list to a single command string for shell=True
-				command_string = subprocess.list2cmdline(args)
-				return subprocess.check_call(command_string, shell=True)
+
+				# Use shutil.which to resolve .cmd/.bat extensions without shell=True
+				import shutil
+				cmd = args[0]
+				resolved_cmd = shutil.which(cmd)
+				if resolved_cmd:
+					args[0] = resolved_cmd
+
+				return subprocess.check_call(args, shell=False)
 			else:
 				return subprocess.check_call(args, shell=False)
 		except subprocess.CalledProcessError as e:

--- a/libs/utility_manager.py
+++ b/libs/utility_manager.py
@@ -43,7 +43,7 @@ class UtilityManager:
 		try:
 			if os.path.isfile(filename):
 				if platform.system() == "Windows":
-					subprocess.call(['start', filename], shell=True)
+					os.startfile(filename)
 				elif platform.system() == "Darwin":
 					subprocess.call(['open', filename])
 				elif platform.system() == "Linux":

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -1780,9 +1780,10 @@ class TestPackageManagerRunCommandSafety(unittest.TestCase):
 	@patch("libs.package_manager.os.name", "nt")
 	def test_windows_safe_args_pass_validation(self):
 		with patch("subprocess.check_call", return_value=0) as mock_call:
-			result = self.pm._run_command(["pip", "install", "requests"])
-		# On Windows, args are converted to a single string via list2cmdline
-		mock_call.assert_called_once_with("pip install requests", shell=True)
+			with patch("shutil.which", return_value="pip"):
+				result = self.pm._run_command(["pip", "install", "requests"])
+		# On Windows, args are passed directly with shell=False
+		mock_call.assert_called_once_with(["pip", "install", "requests"], shell=False)
 
 	@patch("libs.package_manager.os.name", "posix")
 	def test_unix_uses_shell_false(self):
@@ -1814,8 +1815,9 @@ class TestPackageManagerRunCommandSafety(unittest.TestCase):
 	def test_windows_called_process_error_is_reraised(self):
 		import subprocess
 		with patch("subprocess.check_call", side_effect=subprocess.CalledProcessError(1, "pip")):
-			with self.assertRaises(subprocess.CalledProcessError):
-				self.pm._run_command(["pip", "install", "requests"])
+			with patch("shutil.which", return_value="pip"):
+				with self.assertRaises(subprocess.CalledProcessError):
+					self.pm._run_command(["pip", "install", "requests"])
 
 
 class TestExecutionSafetyManagerSandbox(unittest.TestCase):


### PR DESCRIPTION
This PR addresses a critical command injection vulnerability caused by the use of `shell=True` in `subprocess` calls on Windows.

**Changes:**
1.  **`libs/package_manager.py`**:
    *   Removed `shell=True` from `subprocess.check_call`.
    *   Added `shutil.which` to correctly resolve executable paths (e.g., `npm.cmd`, `pip.exe`) without needing the shell.
    *   Updated the `safe_pattern` regex to allow path separators (`/`, `\`) and drive letters (`:`), since `shutil.which` returns absolute paths.
    *   Ensured `args` is a mutable list before modifying `args[0]`.
2.  **`libs/utility_manager.py`**:
    *   Replaced `subprocess.call(['start', filename], shell=True)` with `os.startfile(filename)` on Windows, completely bypassing shell invocation for file opening.
3.  **`tests/test_interpreter.py`**:
    *   Updated tests to expect `shell=False` and mocked `shutil.which` where appropriate.

**Verification:**
*   All unit tests run correctly (`python3 -m pytest tests/`).

---
*PR created automatically by Jules for task [10982852139776001829](https://jules.google.com/task/10982852139776001829) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved command execution safety on Windows through enhanced argument validation and updated subprocess invocation methods for critical operations
  * Refactored Windows file-opening behavior to use native system APIs for improved compatibility and reliability

* **Tests**
  * Updated test suite to reflect changes in Windows subprocess execution behavior and safety validations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/code-interpreter/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->