### PR TITLE
🎨 Palette: [UX improvement] Fix TUI keyboard traps and improve discoverability

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-29 - TUI Keyboard Traps and Discoverability
+**Learning:** In terminal environments, raw input modes can swallow standard OS interrupt signals (like `\x03` for Ctrl-C), trapping users. Additionally, TUI elements without explicit shortcut hints and non-TTY prompts without explicit choices leave users guessing.
+**Action:** Always map standard interrupt bytes to exit actions in raw mode, explicitly render cancel shortcuts (e.g., 'Esc/Ctrl-C to cancel'), and format choices directly into non-TTY prompts avoiding strict validation pitfalls.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -25,7 +25,7 @@ class TerminalUI:
                 return mapping.get(extended, extended)
             if key == '\r':
                 return 'enter'
-            if key == '\x1b':
+            if key in ('\x1b', '\x03'):
                 return 'escape'
             return key
 
@@ -43,6 +43,8 @@ class TerminalUI:
                 return mapping.get(next_chars, 'escape')
             if key in ('\r', '\n'):
                 return 'enter'
+            if key == '\x03':
+                return 'escape'
             return key
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
@@ -67,7 +69,9 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        base_msg = 'Use Up/Down arrows and Enter to select.'
+        cancel_msg = '(Esc/Ctrl-C to cancel)'
+        footer = f"{help_text} {cancel_msg}" if help_text else f"{base_msg} {cancel_msg}"
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +80,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
🎨 Palette: [UX improvement] Fix TUI keyboard traps and improve discoverability

💡 What: Mapped `\x03` (Ctrl-C) to 'escape' in terminal raw input loops for both Windows and Unix paths. Added an explicit `(Esc/Ctrl-C to cancel)` hint to the TUI footer. Modified the non-TTY `Prompt.ask` to explicitly display available choices directly in the prompt string.
🎯 Why: In raw terminal mode, standard OS interrupts are often swallowed, trapping users in the TUI without a clear way out if they try to Ctrl-C. Furthermore, omitting shortcuts in the TUI footer and hiding choices in the non-TTY fallback leaves users guessing what to do next.
♿ Accessibility: Improves terminal keyboard accessibility by ensuring standard exit patterns (Ctrl-C, Esc) reliably function to cancel out of TUI menus, and enhances cognitive accessibility by explicitly visualizing available choices and shortcuts.

---
*PR created automatically by Jules for task [1614048011574792078](https://jules.google.com/task/1614048011574792078) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal UI now consistently recognizes Ctrl-C as a cancellation signal across platforms.
  * Cancel instructions (Esc/Ctrl-C) are now explicitly displayed in selector prompts.
  * Non-interactive prompts now display available options inline for better clarity.

* **Documentation**
  * Added guidance on terminal UI keyboard handling and user discoverability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/code-interpreter/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->