### PR TITLE
🎨 Palette: [UX improvement] Enhance TUI interactivity and interrupt handling

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-24 - Interactive Prompts and TUI UX
+**Learning:** Terminal UI (TUI) components in headless environments require explicit inline choices in prompts. Additionally, raw mode keyboard handling must explicitly map standard interrupt bytes (like `\x03` for Ctrl+C) to prevent keyboard traps.
+**Action:** Always provide explicit choice options inline for fallback prompts and manually map interrupt signals in TUI raw mode implementation.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -67,7 +67,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = help_text or 'Use Up/Down arrows and Enter to select. Esc/Ctrl-C to cancel.'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +76,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:
@@ -99,7 +99,7 @@ class TerminalUI:
                 selected_index = (selected_index + 1) % len(options)
             elif key == 'enter':
                 return options[selected_index]
-            elif key == 'escape':
+            elif key in ('escape', '\x03'):
                 raise KeyboardInterrupt('Selection cancelled by user.')
             elif isinstance(key, str) and len(key) == 1:
                 lowered = key.lower()


### PR DESCRIPTION
💡 What: Added explicit inline choices for prompts when TTY is unavailable, clarified the cancellation shortcut (Esc/Ctrl-C) in the TUI footer, and explicitly mapped `\x03` (Ctrl-C) to trigger an exit in raw keyboard mode.
🎯 Why: To make the terminal interface more intuitive, provide clearer fallback prompts in headless testing environments, and prevent the application from acting as a keyboard trap when users intuitively press Ctrl-C.
📸 Before/After: N/A (Terminal UI tweaks, no visual HTML change)
♿ Accessibility: Prevents "keyboard traps" in the raw-mode terminal interface and provides better explicit guidance for cancellation and selection, improving general usability.

---
*PR created automatically by Jules for task [591284406558102273](https://jules.google.com/task/591284406558102273) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Terminal UI selector prompts now display available options directly within the prompt text for improved clarity.
  * Default help messaging expanded to include clear cancellation instructions.

* **Bug Fixes**
  * Terminal UI now consistently recognizes both Escape and Ctrl-C as cancellation commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/haseeb-heaven/code-interpreter/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->