### PR TITLE
🎨 Palette: [UX improvement] Support Ctrl-C and add exit hints in TUI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-31 - Avoid terminal keyboard traps
+**Learning:** In terminal UIs running in raw mode, standard interrupts like Ctrl-C (`\x03`) are often captured as raw input. Without explicit handling and visible hints, users can get trapped in selection loops, leading to a frustrating experience.
+**Action:** Always map standard interrupt bytes (`\x03`) to exit/cancel actions and explicitly document shortcuts like "Esc/Ctrl-C to cancel" in the UI footer for discoverability.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -67,7 +67,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = help_text or 'Use Up/Down arrows and Enter to select. Esc/Ctrl-C to cancel.'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -99,7 +99,7 @@ class TerminalUI:
                 selected_index = (selected_index + 1) % len(options)
             elif key == 'enter':
                 return options[selected_index]
-            elif key == 'escape':
+            elif key in ('escape', '\x03'):
                 raise KeyboardInterrupt('Selection cancelled by user.')
             elif isinstance(key, str) and len(key) == 1:
                 lowered = key.lower()


### PR DESCRIPTION
💡 What: Added support for Ctrl-C (`\x03`) to exit TUI selection prompts and updated the footer text to explicitly mention "Esc/Ctrl-C to cancel".
🎯 Why: Users expect Ctrl-C to cancel terminal prompts. Previously, pressing Ctrl-C in raw mode did nothing, trapping users unless they guessed to press Escape. The added text improves discoverability.
📸 Before/After: N/A
♿ Accessibility: Prevents a keyboard trap in terminal UI raw mode, making the interface more predictable and user-friendly for keyboard users.

---
*PR created automatically by Jules for task [7164315739090522758](https://jules.google.com/task/7164315739090522758) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on handling terminal keyboard interrupts to prevent input traps.

* **Bug Fixes**
  * Terminal selection operations now properly cancel when Ctrl-C is pressed.
  * Updated help prompts to indicate Esc or Ctrl-C can cancel operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->