### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix command injection in _open_resource_file

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-01 - Prevent Command Injection on Windows File Open
+**Vulnerability:** Command injection vulnerability due to using `subprocess.call(['start', filename], shell=True)` on Windows in `UtilityManager._open_resource_file`.
+**Learning:** Using `shell=True` with unvalidated input (like filenames) exposes the application to command injection.
+**Prevention:** Use `os.startfile(filename)` instead to open files on Windows, which directly opens the file without invoking the command shell, avoiding the risk entirely.

--- a/libs/utility_manager.py
+++ b/libs/utility_manager.py
@@ -43,7 +43,7 @@ class UtilityManager:
 		try:
 			if os.path.isfile(filename):
 				if platform.system() == "Windows":
-					subprocess.call(['start', filename], shell=True)
+					os.startfile(filename)
 				elif platform.system() == "Darwin":
 					subprocess.call(['open', filename])
 				elif platform.system() == "Linux":


### PR DESCRIPTION
- 🚨 Severity: HIGH
- 💡 Vulnerability: Command injection in `_open_resource_file` via `subprocess.call(..., shell=True)` on Windows.
- 🎯 Impact: An attacker or malicious input could execute arbitrary system commands on Windows if a crafted filename is passed.
- 🔧 Fix: Replaced `subprocess.call(['start', filename], shell=True)` with `os.startfile(filename)`.
- ✅ Verification: Tested using the unittest suite, and code review confirms no more `shell=True`.

---
*PR created automatically by Jules for task [6990336611878737903](https://jules.google.com/task/6990336611878737903) started by @haseeb-heaven*