### PR TITLE
🎨 Palette: [UX improvement] Improve TUI interactive hints and controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-02 - TUI Keyboard Traps and Discoverability
+**Learning:** In terminal UIs running in raw mode, handling standard exit bytes like `\x03` (Ctrl-C) is critical to prevent keyboard traps. Additionally, explicit hints (like 'Esc/Ctrl-C to cancel' or listing choices in headless prompts) dramatically improve discoverability and accessibility.
+**Action:** Always map standard interrupt bytes to exit actions in raw mode terminal loops and explicitly surface available shortcut hints to users.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -68,6 +68,7 @@ class TerminalUI:
             table.add_row(marker, label, style=style)
 
         footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer += ' (Esc/Ctrl-C to cancel)'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +77,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:
@@ -99,7 +100,7 @@ class TerminalUI:
                 selected_index = (selected_index + 1) % len(options)
             elif key == 'enter':
                 return options[selected_index]
-            elif key == 'escape':
+            elif key in ('escape', '\x03'):
                 raise KeyboardInterrupt('Selection cancelled by user.')
             elif isinstance(key, str) and len(key) == 1:
                 lowered = key.lower()


### PR DESCRIPTION
💡 What
- Added `Esc/Ctrl-C to cancel` hints to the TUI interaction footer.
- Surfaced explicitly available options when displaying plain-text prompts (by formatting `[options]`).
- Caught the standard `Ctrl-C` byte (`\x03`) in raw keyboard input loops, raising a clean KeyboardInterrupt.

🎯 Why
- Explicit shortcuts drastically improve discoverability for users who may not inherently know the exit commands for a TUI.
- Preventing keyboard traps in raw-mode (where users press Ctrl-C and nothing happens) is a critical standard of CLI user experience.
- When `rich` prompts fallback to text, hiding valid input options leads to frustrating trial-and-error. Explicitly rendering `[opt1|opt2]` solves this.

📸 Before/After
- Before: Prompt asked "Mode" and users had to guess valid options if not displayed as a table.
- After: Prompt asks "Mode [code|chat|script|command|vision]"
- Before: No visual indication of how to cancel out of a selection loop.
- After: `(Esc/Ctrl-C to cancel)` permanently rendered in the prompt panel.

♿ Accessibility
- Prevents keyboard trapping by fully honoring system interrupt bytes.
- Better cognitive accessibility by providing immediate shortcuts and visual hints, removing the need for user memorization.

---
*PR created automatically by Jules for task [9262072439929030398](https://jules.google.com/task/9262072439929030398) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced terminal UI keyboard handling to support both Esc and Ctrl-C for cancellation, preventing keyboard traps
  * Updated selector prompts to explicitly display available choices and cancellation shortcuts for improved discoverability
* **Documentation**
  * Added terminal UI raw-mode keyboard handling documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->