### PR TITLE
🎨 Palette: [UX improvement] Fix TUI keyboard traps and improve headless prompt choices

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-01-01 - TUI Keyboard Traps and Shortcut Hints
+**Learning:** In raw terminal modes, failing to map standard interrupt bytes (\x03) creates keyboard traps. Additionally, explicit shortcut hints and visible prompt choices are essential for terminal accessibility, mirroring web micro-UX practices.
+**Action:** Always map \x03 to exit actions in raw mode, explicitly render choice options in headless prompts, and display clear exit shortcut hints (e.g., 'Esc/Ctrl-C to cancel') in TUI footers.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -25,7 +25,7 @@ class TerminalUI:
                 return mapping.get(extended, extended)
             if key == '\r':
                 return 'enter'
-            if key == '\x1b':
+            if key in ('\x1b', '\x03'):
                 return 'escape'
             return key
 
@@ -41,6 +41,8 @@ class TerminalUI:
                 next_chars = sys.stdin.read(2)
                 mapping = {'[A': 'up', '[B': 'down', '[D': 'left', '[C': 'right'}
                 return mapping.get(next_chars, 'escape')
+            if key == '\x03':
+                return 'escape'
             if key in ('\r', '\n'):
                 return 'enter'
             return key
@@ -68,6 +70,7 @@ class TerminalUI:
             table.add_row(marker, label, style=style)
 
         footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer += ' | Esc/Ctrl-C to cancel'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +79,8 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            options_str = '|'.join(options)
+            answer = Prompt.ask(f"{title} \\[{options_str}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
💡 What:
- Mapped standard terminal interrupt byte (`\x03`, Ctrl-C) to trigger the `escape` action in raw TUI mode, preventing keyboard traps.
- Added explicit visual shortcut hints (`| Esc/Ctrl-C to cancel`) to the TUI footer.
- Updated the fallback headless `Prompt.ask` to render explicitly the available input choices inline.

🎯 Why:
- Raw terminal interactions can trap users if they attempt to use familiar exit sequences like Ctrl-C, frustrating their experience. Providing clear exit indications, mappings, and visibly surfaced choices directly aligns with web-based micro-UX principles ported to the CLI.

📸 Before/After:
Before:
`Test (a):`
After:
`Test [a|b] (a):`

♿ Accessibility:
- Eliminates keyboard traps for assistive and non-assistive users alike by globally capturing the standard terminal interrupt.
- Exposes choices overtly without requiring them to trigger errors first in headless modes.

---
*PR created automatically by Jules for task [2390350896898547139](https://jules.google.com/task/2390350896898547139) started by @haseeb-heaven*