### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in resource opener

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-06-05 - Command Injection via subprocess.call with shell=True
+**Vulnerability:** Use of `subprocess.call(['start', filename], shell=True)` for opening files on Windows.
+**Learning:** Even when invoking the shell with a list of arguments, `shell=True` can evaluate special characters in the filename, allowing command injection on Windows.
+**Prevention:** Use `os.startfile(filename)` when opening files on Windows to avoid invoking the shell entirely.

--- a/libs/utility_manager.py
+++ b/libs/utility_manager.py
@@ -43,7 +43,7 @@ class UtilityManager:
 		try:
 			if os.path.isfile(filename):
 				if platform.system() == "Windows":
-					subprocess.call(['start', filename], shell=True)
+					os.startfile(filename)
 				elif platform.system() == "Darwin":
 					subprocess.call(['open', filename])
 				elif platform.system() == "Linux":


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Command injection vulnerability on Windows via `subprocess.call(..., shell=True)` when handling file paths.
🎯 Impact: If a maliciously crafted filename bypasses checks, it could allow arbitrary command execution.
🔧 Fix: Replaced `subprocess.call` with `os.startfile` to avoid shell invocation entirely.
✅ Verification: Run `python3 -m pytest tests/` to confirm tests pass, and visually verify code uses `os.startfile`.

---
*PR created automatically by Jules for task [17111070492163483188](https://jules.google.com/task/17111070492163483188) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Windows security vulnerability involving command injection when opening files. The application now uses a safer method to open resource files, improving overall security.

* **Documentation**
  * Added security guidance documentation detailing the vulnerability and prevention measures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->