### PR TITLE
🎨 Palette: Prevent Keyboard Traps in Terminal UI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2025-02-23 - Prevent Keyboard Traps in Terminal UI
+**Learning:** Terminal equivalents of web accessibility (like preventing keyboard traps) require mapping standard interrupt bytes (e.g., `\x03` for Ctrl-C) to exit actions in raw mode, and providing explicit visual hints for these shortcuts.
+**Action:** Always ensure raw terminal input modes explicitly handle interrupt bytes to prevent keyboard traps, and update TUI prompts to clearly display available choices and cancellation shortcuts.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -19,6 +19,8 @@ class TerminalUI:
         if os.name == 'nt':
             import msvcrt
             key = msvcrt.getwch()
+            if key == '\x03':
+                raise KeyboardInterrupt
             if key in ('\x00', '\xe0'):
                 extended = msvcrt.getwch()
                 mapping = {'H': 'up', 'P': 'down', 'K': 'left', 'M': 'right'}
@@ -37,6 +39,8 @@ class TerminalUI:
         try:
             tty.setraw(fd)
             key = sys.stdin.read(1)
+            if key == '\x03':
+                raise KeyboardInterrupt
             if key == '\x1b':
                 next_chars = sys.stdin.read(2)
                 mapping = {'[A': 'up', '[B': 'down', '[D': 'left', '[C': 'right'}
@@ -68,6 +72,8 @@ class TerminalUI:
             table.add_row(marker, label, style=style)
 
         footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        if 'Esc/Ctrl-C' not in footer:
+            footer += ' (Esc/Ctrl-C to cancel)'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +82,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
* 💡 What: Added explicit "Esc/Ctrl-C to cancel" hint and implemented Ctrl-C (`\x03`) interrupt in raw TUI mode. Updated `Prompt.ask` to clearly display valid options.
* 🎯 Why: To prevent keyboard traps in terminal UI raw mode and improve accessibility by making input choices explicit.
* 📸 Before/After: Before: Users couldn't exit raw mode easily with Ctrl-C and options were hidden. After: Users are guided on how to cancel and choices are explicitly listed.
* ♿ Accessibility: Improved keyboard accessibility by mapping the standard interrupt byte and improved clarity by explicitly displaying options.

---
*PR created automatically by Jules for task [4854193483749370901](https://jules.google.com/task/4854193483749370901) started by @haseeb-heaven*