### PR TITLE
🎨 Palette: Add TUI shortcut hints and prevent raw mode keyboard traps

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-01-01 - Terminal UI Accessibility
+**Learning:** When falling back to headless or text inputs from TUI, explicit prompt choices help users, and avoiding keyboard traps (by explicitly handling Ctrl-C /  in raw TTY mode) prevents user frustration.
+**Action:** Explicitly bind interrupt bytes like  to exit actions in raw terminal interfaces and surface keyboard shortcuts clearly in instructions.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -25,7 +25,7 @@ class TerminalUI:
                 return mapping.get(extended, extended)
             if key == '\r':
                 return 'enter'
-            if key == '\x1b':
+            if key in ('\x1b', '\x03'):
                 return 'escape'
             return key
 
@@ -43,6 +43,8 @@ class TerminalUI:
                 return mapping.get(next_chars, 'escape')
             if key in ('\r', '\n'):
                 return 'enter'
+            if key == '\x03':
+                return 'escape'
             return key
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
@@ -68,6 +70,7 @@ class TerminalUI:
             table.add_row(marker, label, style=style)
 
         footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer += ' (Esc/Ctrl-C to cancel)'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +79,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
- 💡 What: Added explicitly formatted options for headless prompts, mapped Ctrl-C (`\x03`) to escape in raw TTY mode, and added a visual shortcut hint for cancel functionality.
- 🎯 Why: To prevent keyboard traps in terminal UI applications where standard interrupts don't work, and to clarify available options and exit keys for users.
- 📸 Before/After: N/A
- ♿ Accessibility: Improved keyboard accessibility (shortcut mapping, trap prevention) and clarity of available choices in non-visual modes.

---
*PR created automatically by Jules for task [5623026908859201607](https://jules.google.com/task/5623026908859201607) started by @haseeb-heaven*