### PR TITLE
🎨 Palette: Handle Ctrl+C properly in raw TUI mode

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Handle Ctrl-C correctly in Terminal UI raw mode
+**Learning:** In terminal raw mode (e.g. using `tty.setraw()`), the `SIGINT` signal (Ctrl-C) is not raised as a `KeyboardInterrupt` by the terminal. Instead, the raw `\x03` byte is passed directly to standard input. This creates a keyboard trap where users cannot intuitively exit the prompt.
+**Action:** Explicitly map the `\x03` byte alongside standard exit sequences (like 'escape') to trigger cancellation, and provide explicit hints in the UI ("Esc/Ctrl-C to cancel") to guide the user.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -67,7 +67,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = help_text or 'Use Up/Down arrows and Enter to select. Esc/Ctrl-C to cancel.'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -99,7 +99,7 @@ class TerminalUI:
                 selected_index = (selected_index + 1) % len(options)
             elif key == 'enter':
                 return options[selected_index]
-            elif key == 'escape':
+            elif key in ('escape', '\x03'):
                 raise KeyboardInterrupt('Selection cancelled by user.')
             elif isinstance(key, str) and len(key) == 1:
                 lowered = key.lower()


### PR DESCRIPTION
💡 What: Mapped `\x03` to trigger cancellation and updated help text.
🎯 Why: Solves a keyboard trap where users could not exit prompts cleanly using Ctrl+C.
📸 Before/After: Before: "Use Up/Down arrows and Enter to select." After: "Use Up/Down arrows and Enter to select. Esc/Ctrl-C to cancel."
♿ Accessibility: Fixes a keyboard trap issue by correctly handling standard interrupt inputs and adding visible shortcut hints.

---
*PR created automatically by Jules for task [11646775387544105720](https://jules.google.com/task/11646775387544105720) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ctrl-C now properly triggers cancellation in terminal UI selection dialogs, providing an alternative to the Escape key

* **User Experience**
  * Updated selection dialog footers to display "Esc/Ctrl-C to cancel" for clearer guidance on available cancellation methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->