### PR TITLE
🎨 Palette: [UX improvement] Fix keyboard trap and improve prompt clarity

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-06-08 - Added explicit Ctrl-C handling in raw terminal and explicit choice hints
+**Learning:** When dealing with terminal UI in raw mode (`tty.setraw`), regular interrupt signals like `Ctrl-C` are disabled and instead passed through as raw byte `\x03`. Users expect `Ctrl-C` to abort or cancel out of UIs, creating a keyboard trap if not manually mapped. Similarly, non-interactive prompts need explicit visual cues (like choice lists) to be accessible.
+**Action:** Always map standard interrupt bytes (like `\x03`) to an exit/cancel action in custom TUI components. Also manually format prompt choices (e.g., `\\[a|b|c]`) when custom processing prevents using `rich`'s built-in `choices` arg.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -25,7 +25,7 @@ class TerminalUI:
                 return mapping.get(extended, extended)
             if key == '\r':
                 return 'enter'
-            if key == '\x1b':
+            if key in ('\x1b', '\x03'):
                 return 'escape'
             return key
 
@@ -41,6 +41,8 @@ class TerminalUI:
                 next_chars = sys.stdin.read(2)
                 mapping = {'[A': 'up', '[B': 'down', '[D': 'left', '[C': 'right'}
                 return mapping.get(next_chars, 'escape')
+            if key == '\x03':
+                return 'escape'
             if key in ('\r', '\n'):
                 return 'enter'
             return key
@@ -67,7 +69,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = help_text or 'Use Up/Down arrows and Enter to select. (Esc/Ctrl-C to cancel)'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +78,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
**💡 What:** Added explicit handling for `Ctrl-C` (`\x03`) in raw mode to cancel selection, updated footer hint, and displayed available options in non-interactive prompts.
**🎯 Why:** Without `\x03` mapping, `tty.setraw` creates a keyboard trap for users used to cancelling with `Ctrl-C`. Non-interactive fallback lacked clear indication of what options were valid.
**📸 Before/After:** Before: pressing `Ctrl-C` does nothing, fallback asks `Mode` without context. After: `Ctrl-C` cancels cleanly, fallback asks `Mode [code|chat|script|command|vision]`.
**♿ Accessibility:** Fixed a keyboard trap (WCAG 2.1.2) allowing users to reliably escape the TUI.

---
*PR created automatically by Jules for task [1689336443450909199](https://jules.google.com/task/1689336443450909199) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal UI now properly responds to Ctrl-C as an exit action
  * Non-interactive prompts now clearly display available choice options
  * Selector help text now mentions Ctrl-C/Esc as cancellation methods

* **Documentation**
  * Updated terminal behavior documentation for raw mode interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->