### PR TITLE
🎨 Palette: Add explicit choice indicators to TUI headless prompts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-06-10 - Improved TUI prompt UX for headless environments
+**Learning:** Using `Prompt.ask` without options makes it unclear what choices the user has in non-interactive mode. However, passing `choices` to rich's `Prompt.ask` makes it case-sensitive, which breaks existing case-insensitivity handling.
+**Action:** Manually format choices into the prompt text with escaped brackets `\\[choice1|choice2\\]` to display available options while preserving custom case-insensitive input parsing.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -76,7 +76,8 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            options_str = '|'.join(options)
+            answer = Prompt.ask(f"{title} \\[{options_str}\\]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
💡 What: Manually formatting choice options (e.g., `[code|chat]`) directly into the prompt string for `rich.prompt.Prompt.ask` when `sys.stdin.isatty()` is False.
🎯 Why: The previous prompt provided no clues to the user regarding the available options in non-interactive or testing environments. We avoid the `choices` kwarg to preserve existing custom case-insensitivity logic.
📸 Before/After: Before: `Mode: ` | After: `Mode \[code|chat\]: `
♿ Accessibility: Improves clarity for headless and automated execution paths by explicitly stating acceptable inputs.

---
*PR created automatically by Jules for task [993448652329842756](https://jules.google.com/task/993448652329842756) started by @haseeb-heaven*