### PR TITLE
🎨 Palette: [UX improvement] Add keyboard trap exit, clear choices, and shortcut hints

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-11 - TUI Keyboard Trap & Options Clarity
+**Learning:** TUI environments in raw mode can trap keyboard interrupts (Ctrl-C) if `\x03` is not explicitly handled, and default rich prompts mask available choices without strict matching.
+**Action:** Explicitly map `\x03` to exit actions, add shortcut hints to footers, and format string prompts to display options clearly.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -25,7 +25,7 @@ class TerminalUI:
                 return mapping.get(extended, extended)
             if key == '\r':
                 return 'enter'
-            if key == '\x1b':
+            if key in ('\x1b', '\x03'):
                 return 'escape'
             return key
 
@@ -43,6 +43,8 @@ class TerminalUI:
                 return mapping.get(next_chars, 'escape')
             if key in ('\r', '\n'):
                 return 'enter'
+            if key == '\x03':
+                return 'escape'
             return key
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
@@ -67,7 +69,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = (help_text or 'Use Up/Down arrows and Enter to select.') + ' Esc/Ctrl-C to cancel.'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +78,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
💡 What: Mapped `\x03` (Ctrl-C) to exit actions in raw mode, exposed choices in non-interactive prompts, and added cancel shortcut hints to the UI footer.
🎯 Why: To prevent terminal keyboard traps, make available choices visible, and give users clear instructions on how to cancel TUI selections.
📸 Before/After: Visual update to prompts to include choice arrays and updated footer strings.
♿ Accessibility: Improved keyboard accessibility by explicitly providing an exit hatch for standard interrupts and making options immediately visible to screen readers using headless prompts.

---
*PR created automatically by Jules for task [15196289772185900456](https://jules.google.com/task/15196289772185900456) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ctrl-C now works consistently as a cancel signal across all platforms
  * UI footer messages now explicitly display available keyboard shortcuts
  * Option prompts now display available choices inline for improved readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->