### PR TITLE
🎨 Palette: Improve TUI shortcut hints and option visibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-13 - Add shortcut hints and explicit options to TUI prompts
+**Learning:** Terminal UI (TUI) environments need clear, visible hints for shortcuts (like Esc/Ctrl-C to cancel) and explicit choices (like showing [python|javascript] instead of hiding it) to avoid keyboard traps and confusion when running in headless mode or non-interactive environments.
+**Action:** Always manually format explicit prompt options with brackets and indicate interrupt mappings in the footer text.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -68,6 +68,8 @@ class TerminalUI:
             table.add_row(marker, label, style=style)
 
         footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        if '(Esc/Ctrl-C to cancel)' not in footer:
+            footer += ' (Esc/Ctrl-C to cancel)'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +78,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:
@@ -99,7 +101,7 @@ class TerminalUI:
                 selected_index = (selected_index + 1) % len(options)
             elif key == 'enter':
                 return options[selected_index]
-            elif key == 'escape':
+            elif key in ('escape', '\x03'):
                 raise KeyboardInterrupt('Selection cancelled by user.')
             elif isinstance(key, str) and len(key) == 1:
                 lowered = key.lower()


### PR DESCRIPTION
* **💡 What:** Added explicit choice brackets to `Prompt.ask` and `(Esc/Ctrl-C to cancel)` hints to the TUI footer.
* **🎯 Why:** Improves accessibility and intuitiveness for users by revealing hidden options and making escape paths obvious.
* **📸 Before/After:** Before: 'Language: ', After: 'Language [python|javascript]: '. Before: 'Use Up/Down arrows and Enter to select.', After: 'Use Up/Down arrows and Enter to select. (Esc/Ctrl-C to cancel)'.
* **♿ Accessibility:** Clarifies interactive prompts for screen readers reading raw text and makes explicit the existing exit bindings.

---
*PR created automatically by Jules for task [1240618998543193238](https://jules.google.com/task/1240618998543193238) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal selector now displays available options inline within selection prompts for improved clarity
  * Added persistent keyboard shortcut hints (Esc/Ctrl-C to cancel) in terminal UI footer

* **Documentation**
  * Updated TUI prompt guidance standards to emphasize clear option presentation and visible shortcut hints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->