### PR TITLE
🎨 Palette: [UX improvement] Add explicit cancellation hint and option visibility in TUI prompts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-06-15 - Explicit Shortcut Hints in TUI
+**Learning:** Users in terminal environments often lack clear discoverability for standard escape actions compared to web UIs. Implicit knowledge like "Esc cancels" shouldn't be assumed.
+**Action:** Always append explicit cancellation shortcuts (e.g., 'Esc to cancel') in terminal UI prompt footers.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -67,7 +67,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = help_text or 'Use Up/Down arrows and Enter to select. Esc to cancel.'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +76,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
💡 What: Updated the TUI selector help text to explicitly mention 'Esc to cancel' and added inline options to non-interactive Prompts.
🎯 Why: Improves keyboard accessibility and discoverability in terminal environments by making available options and cancellation shortcuts explicit.
📸 Before/After: Help text changed from '...Enter to select.' to '...Enter to select. Esc to cancel.'
♿ Accessibility: Enhances cognitive accessibility by not relying on implicit knowledge of terminal conventions.

---
*PR created automatically by Jules for task [1429867759782654953](https://jules.google.com/task/1429867759782654953) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Selection prompts in terminal UI now display "Esc to cancel" hints for improved navigation
  * Option prompts now show allowed options inline in non-interactive mode

* **Documentation**
  * Updated terminal UI guidelines to include explicit shortcut and cancellation hints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->