### PR TITLE
🎨 Palette: Improve TUI accessibility and explicit keyboard hints

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-20 - TUI Accessibility and Keyboard Traps
+**Learning:** Terminal UIs can trap keyboard users when standard interrupt bytes (\x03) are caught by raw mode without an explicit exit path, and headless prompts without inline choices lack intuitiveness.
+**Action:** Always map \x03 to explicitly raise KeyboardInterrupt in TUI raw mode, include inline choices for text prompts, and provide explicit shortcut hints (Esc/Ctrl-C) in footers.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -43,6 +43,8 @@ class TerminalUI:
                 return mapping.get(next_chars, 'escape')
             if key in ('\r', '\n'):
                 return 'enter'
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
             return key
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
@@ -67,7 +69,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = help_text or 'Use Up/Down arrows and Enter to select. (Esc/Ctrl-C to cancel)'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +78,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:
@@ -110,7 +112,7 @@ class TerminalUI:
 
     def _select_boolean(self, title, default=False):
         default_choice = 'yes' if default else 'no'
-        choice = self._select_option(title, ['yes', 'no'], default_choice, 'Use Up/Down arrows and Enter to choose.')
+        choice = self._select_option(title, ['yes', 'no'], default_choice, 'Use Up/Down arrows and Enter to choose. (Esc/Ctrl-C to cancel)')
         return choice == 'yes'
 
     def select_mode(self, default_mode='code'):


### PR DESCRIPTION
💡 What: Added inline choices for headless prompts, explicit shortcut hints in footers, and Ctrl-C handling in raw mode.
🎯 Why: Enhances terminal UX by preventing keyboard traps, improving clarity of available options, and making shortcuts explicit.
📸 Before/After: Before, no options were visible in headless prompts and Ctrl-C was ignored in raw mode. After, choices are inline and Ctrl-C properly exits.
♿ Accessibility: Ensures keyboard users are not trapped in menus and options are clearly discoverable without guesswork.

---
*PR created automatically by Jules for task [4943688031202912308](https://jules.google.com/task/4943688031202912308) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Terminal UI now displays explicit keyboard shortcut hints (Esc/Ctrl-C to cancel) in selector help text for better accessibility.
  * Option prompts now show available choices inline for clearer selection guidance.
  * Enhanced keyboard interrupt handling during interactive selection.

* **Bug Fixes**
  * Ctrl-C now properly cancels interactive selections with clear user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->