### PR TITLE
🎨 Palette: Display explicit options in terminal UI prompt

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Display explicit prompt choices in TUI
+**Learning:** Explicitly surfacing valid choices within the terminal prompt (e.g. `Mode [code|chat|script|command|vision]`) significantly improves UX and accessibility, especially when headless or non-interactive fallback mode is used.
+**Action:** When using `rich` Prompt.ask, explicitly manually format choices into the prompt string and escape markup brackets as `\\[` instead of using the `choices` argument to prevent breaking custom case-insensitivity logic.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -76,7 +76,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
💡 What: Modified `TerminalUI._select_option` to explicitly display available choices in the prompt text.
🎯 Why: To improve discoverability and usability when running in non-interactive/headless environments, since users need to know valid inputs.
📸 Before/After: N/A
♿ Accessibility: Improves cognitive accessibility by clearly stating the allowed inputs upfront.

---
*PR created automatically by Jules for task [7235320314396827914](https://jules.google.com/task/7235320314396827914) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal selection prompts have been significantly enhanced to explicitly display all available options directly within the prompt text. Options are now shown alongside the selection title, providing users with immediate visibility into all valid input choices during interactive command-line operations without requiring additional documentation lookups or references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->