### PR TITLE
🎨 Palette: [UX improvement] Better Terminal Interrupt UX and Shortcut Hints

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-06-19 - Keyboard Interrupt Handling in Raw Terminal Mode
+**Learning:** In terminal UI implementations (like `libs/terminal_ui.py`), mapping standard interrupt bytes (like `\x03` for Ctrl-C) strictly to generic `KeyboardInterrupt` rather than internal UI actions prevents keyboard traps, letting users naturally exit interactive selections with familiar shortcuts. Also, UI prompts should explicitly hint this shortcut (e.g., "(Esc/Ctrl-C to cancel)").
+**Action:** Always ensure terminal input loops in raw mode handle `\x03` to cleanly abort, and provide explicit hints for shortcut keys in UI component footers.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -27,6 +27,8 @@ class TerminalUI:
                 return 'enter'
             if key == '\x1b':
                 return 'escape'
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
             return key
 
         import termios
@@ -43,6 +45,8 @@ class TerminalUI:
                 return mapping.get(next_chars, 'escape')
             if key in ('\r', '\n'):
                 return 'enter'
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
             return key
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
@@ -68,6 +72,7 @@ class TerminalUI:
             table.add_row(marker, label, style=style)
 
         footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer += ' (Esc/Ctrl-C to cancel)'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +81,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
💡 What:
- Mapped the standard `\x03` (Ctrl-C) byte to explicitly raise `KeyboardInterrupt` in raw terminal input mode across OS platforms.
- Added explicit "(Esc/Ctrl-C to cancel)" hints in the interactive selector footer.
- Fixed the fallback `rich.prompt.ask` rendering to cleanly display options brackets without parsing as markup tags.

🎯 Why:
- In raw TUI modes, users often intuitively reach for standard shell interrupt commands like `Ctrl-C`. Swallowing these bytes or routing them improperly creates keyboard traps. This translates the concept of standard form 'cancellation' into an intuitive terminal equivalent. 

📸 Before/After:
- Before: Attempting to `Ctrl-C` during interactive raw-mode prompts would trap the user, forcing them to learn alternative ways out or crash out forcefully. Prompts also lacked explicit escape hints.
- After: `Ctrl-C` naturally aborts the selection using familiar OS signals, and prompts explicitly guide the user on how to back out safely.

♿ Accessibility:
- Improves navigability and error recovery by clearly documenting exit routes and adhering to conventional user expectations for keyboard interrupts in terminal environments.

---
*PR created automatically by Jules for task [17867529562245656861](https://jules.google.com/task/17867529562245656861) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidelines for proper Ctrl-C handling and UI cancellation hints in terminal interfaces

* **Bug Fixes**
  * Terminal UI now properly handles Ctrl-C as a clean cancellation action across all input loops
  * Selection prompts display available options inline within the prompt for improved discoverability
  * UI prompts now explicitly show "(Esc/Ctrl-C to cancel)" shortcut hints for clearer user guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->