### PR TITLE
🎨 Palette: Add explicit TUI prompt choices and shortcut hints

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-20 - TUI Prompt Choices and Shortcuts
+**Learning:** In terminal UI environments like this repository, web-specific UX concepts translate to terminal equivalents such as using explicit prompt choices (e.g., via `rich` Prompt.ask), clear shortcut hints ('Esc/Ctrl-C to cancel'), and avoiding keyboard traps by explicitly raising `KeyboardInterrupt` when standard interrupt bytes (`\x03`) are read in raw mode, rather than mapping them to internal UI escape actions.
+**Action:** Always provide explicit keyboard shortcut hints and explicit options for prompts in raw terminal UIs. Ensure `\x03` explicitly raises `KeyboardInterrupt`.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -23,6 +23,8 @@ class TerminalUI:
                 extended = msvcrt.getwch()
                 mapping = {'H': 'up', 'P': 'down', 'K': 'left', 'M': 'right'}
                 return mapping.get(extended, extended)
+            if key == '\x03':
+                raise KeyboardInterrupt()
             if key == '\r':
                 return 'enter'
             if key == '\x1b':
@@ -37,6 +39,8 @@ class TerminalUI:
         try:
             tty.setraw(fd)
             key = sys.stdin.read(1)
+            if key == '\x03':
+                raise KeyboardInterrupt()
             if key == '\x1b':
                 next_chars = sys.stdin.read(2)
                 mapping = {'[A': 'up', '[B': 'down', '[D': 'left', '[C': 'right'}
@@ -67,7 +71,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = f"{help_text or 'Use Up/Down arrows and Enter to select.'} (Esc/Ctrl-C to cancel)"
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +80,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
💡 What: Added explicit options to `Prompt.ask` and added `(Esc/Ctrl-C to cancel)` hint to the TUI footer. Also fixed a keyboard trap by ensuring Ctrl-C (`\x03`) raises `KeyboardInterrupt`.
🎯 Why: Makes the UI more intuitive by showing available choices in headless mode, provides clear navigation instructions in the TUI, and prevents users from getting stuck in a raw terminal mode.
📸 Before/After: N/A (terminal UI)
♿ Accessibility: Improves keyboard navigation clarity and prevents keyboard traps.

---
*PR created automatically by Jules for task [11336086925080219262](https://jules.google.com/task/11336086925080219262) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Ctrl-C handling in terminal prompts to properly trigger cancellation.

* **New Features**
  * Terminal prompts now explicitly display available options and cancellation shortcuts (Esc/Ctrl-C) in help text for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->