### PR TITLE
🎨 Palette: [UX improvement] Fix terminal TUI keyboard trap and provide clear exit hints

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Handle Terminal Raw Mode Keyboard Traps
+**Learning:** When creating terminal UIs with raw mode, `\x03` (Ctrl-C) must be explicitly trapped and raised as `KeyboardInterrupt`, otherwise it creates a keyboard trap where standard interrupt keys are ignored. It's also important to explicitly format choices in `rich` Prompts while escaping markup to avoid fallback issues.
+**Action:** Always add explicit keyboard interrupt handling for `\x03` and clear exit instructions ('Esc/Ctrl-C to cancel') in terminal UI raw modes.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -27,6 +27,8 @@ class TerminalUI:
                 return 'enter'
             if key == '\x1b':
                 return 'escape'
+            if key == '\x03':
+                raise KeyboardInterrupt
             return key
 
         import termios
@@ -37,6 +39,8 @@ class TerminalUI:
         try:
             tty.setraw(fd)
             key = sys.stdin.read(1)
+            if key == '\x03':
+                raise KeyboardInterrupt
             if key == '\x1b':
                 next_chars = sys.stdin.read(2)
                 mapping = {'[A': 'up', '[B': 'down', '[D': 'left', '[C': 'right'}
@@ -67,7 +71,8 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        base_text = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = f"{base_text} Esc/Ctrl-C to cancel."
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +81,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
*   **💡 What:** We added explicit handling for the `\x03` (Ctrl-C) byte in the terminal raw input loop (`_read_key`) for both Unix and Windows. We also added an explicit hint to the footer (`Esc/Ctrl-C to cancel.`) and updated the prompt fallback to format choices directly into the text (so `rich` Prompt fallback does not fail invisibly).
*   **🎯 Why:** When terminal raw mode is enabled, it prevents standard OS-level SIGINT signals from firing. If an explicit trap isn't implemented for `\x03`, the user encounters a keyboard trap and cannot easily exit the application gracefully. Fallbacks also need to clearly state what inputs are accepted without triggering syntax errors due to rich markup.
*   **📸 Before/After:**
    *   **Before:** Users pressing Ctrl-C in terminal selector menus did nothing. Fallbacks lacked formatted hints for default options.
    *   **After:** Users pressing Ctrl-C correctly triggers a `KeyboardInterrupt` to exit or cancel gracefully. Fallback prompts explicitly read `[code|chat|...]` correctly escaped. The UI correctly renders `Use Up/Down arrows and Enter to select. Esc/Ctrl-C to cancel.` in the footer.
*   **♿ Accessibility:** Fixing a keyboard trap is a critical accessibility requirement (WCAG 2.1.2 No Keyboard Trap), ensuring users are never "stuck" within an interactive loop that they cannot escape via standard key bindings. Providing explicit UI guidance lowers cognitive load.

---
*PR created automatically by Jules for task [14208961604337589538](https://jules.google.com/task/14208961604337589538) started by @haseeb-heaven*