### PR TITLE
🎨 Palette: Fix keyboard trap on TUI selector

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-22 - TUI Keyboard Trap Fix
+**Learning:** When building terminal UIs with explicit raw mode reading (like bypassing `rich` prompt and using `tty.setraw`), standard interrupt combinations like Ctrl-C (`\x03`) do not raise `KeyboardInterrupt` by default. This causes a severe keyboard trap that prevents users from cleanly escaping out of selection states.
+**Action:** Always intercept `\x03` explicitly when parsing raw keystrokes in terminal interactions and manually raise `KeyboardInterrupt` to preserve accessible escape hatches.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -19,6 +19,8 @@ class TerminalUI:
         if os.name == 'nt':
             import msvcrt
             key = msvcrt.getwch()
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
             if key in ('\x00', '\xe0'):
                 extended = msvcrt.getwch()
                 mapping = {'H': 'up', 'P': 'down', 'K': 'left', 'M': 'right'}
@@ -37,6 +39,8 @@ class TerminalUI:
         try:
             tty.setraw(fd)
             key = sys.stdin.read(1)
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
             if key == '\x1b':
                 next_chars = sys.stdin.read(2)
                 mapping = {'[A': 'up', '[B': 'down', '[D': 'left', '[C': 'right'}


### PR DESCRIPTION
💡 What: Added explicit handling for the `\x03` (Ctrl-C) byte during raw keyboard input reading within `libs/terminal_ui.py`.
🎯 Why: In raw mode, `Ctrl-C` does not naturally raise a `KeyboardInterrupt`. Without checking for it explicitly, users become trapped in the TUI selector with no standard escape route, breaking their mental model of terminal abort functionality.
📸 Before/After: Before, pressing Ctrl-C in the TUI selection would do nothing or return `\x03` as an unhandled byte, ignoring the interrupt. After, pressing Ctrl-C properly aborts the selection loop by explicitly raising a `KeyboardInterrupt` and allowing standard app flow to safely exit.
♿ Accessibility: Ensures that keyboard shortcuts crucial for navigation and state escape are universally supported across the terminal, avoiding keyboard traps which severely degrade user experience for those relying on standard interrupts to back out.

---
*PR created automatically by Jules for task [3388155600786924922](https://jules.google.com/task/3388155600786924922) started by @haseeb-heaven*