### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Command Injection in file opening

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-03 - Command Injection in UtilityManager._open_resource_file via `os.system` / `subprocess.call` shell=True
+**Vulnerability:** The `UtilityManager._open_resource_file` method accepts a `filename` and opens it. On Windows, it uses `subprocess.call(['start', filename], shell=True)`. Filenames containing metacharacters (e.g. `&`) could lead to command injection even if `os.path.isfile(filename)` is true on Windows.
+**Learning:** `os.path.isfile()` checks are insufficient to prevent command injection when `shell=True` is used on Windows, as valid Windows filenames can contain characters like `&` or `^`.
+**Prevention:** Use `os.startfile(filename)` instead of `subprocess.call(['start', filename], shell=True)` on Windows to avoid opening a shell and preventing injection.

--- a/libs/utility_manager.py
+++ b/libs/utility_manager.py
@@ -43,7 +43,7 @@ class UtilityManager:
 		try:
 			if os.path.isfile(filename):
 				if platform.system() == "Windows":
-					subprocess.call(['start', filename], shell=True)
+					os.startfile(filename)
 				elif platform.system() == "Darwin":
 					subprocess.call(['open', filename])
 				elif platform.system() == "Linux":


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Command injection via unescaped filenames when opening files on Windows.
🎯 Impact: Arbitrary command execution on Windows platforms if a user-supplied filename containing shell metacharacters is opened.
🔧 Fix: Replaced `subprocess.call(['start', filename], shell=True)` with `os.startfile(filename)`.
✅ Verification: Run `python3 -m pytest tests/` and `flake8`.

---
*PR created automatically by Jules for task [17326007696993011078](https://jules.google.com/task/17326007696993011078) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security vulnerability in file-opening operations on Windows systems that could allow unauthorized command execution through specially crafted inputs.

* **Documentation**
  * Added comprehensive documentation describing the security vulnerability and the protective measures implemented to prevent exploitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->