### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection in resource file opening

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-01-01 - Command Injection via `shell=True` on Windows File Execution
+**Vulnerability:** Command injection when opening files on Windows using `subprocess.call(['start', filename], shell=True)`.
+**Learning:** `os.path.isfile(filename)` is insufficient to prevent command injection because valid Windows filenames can contain shell metacharacters like `&` and `^`.
+**Prevention:** Use `os.startfile(filename)` which executes the file with its associated application without involving a shell.

--- a/libs/utility_manager.py
+++ b/libs/utility_manager.py
@@ -43,7 +43,7 @@ class UtilityManager:
 		try:
 			if os.path.isfile(filename):
 				if platform.system() == "Windows":
-					subprocess.call(['start', filename], shell=True)
+					os.startfile(filename)
 				elif platform.system() == "Darwin":
 					subprocess.call(['open', filename])
 				elif platform.system() == "Linux":


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Command injection vulnerability on Windows via `subprocess.call(['start', filename], shell=True)` because file names can legally contain shell metacharacters like `&` and `^`.
🎯 Impact: An attacker or maliciously crafted file name could execute arbitrary shell commands when the resource file is opened on Windows.
🔧 Fix: Replaced `subprocess.call(['start', filename], shell=True)` with `os.startfile(filename)` which safely opens files using their associated applications without using the shell.
✅ Verification: Ran the test suite and linters to ensure existing tests pass and the code is syntactically valid.

---
*PR created automatically by Jules for task [215485934827936903](https://jules.google.com/task/215485934827936903) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file opening on Windows to avoid command-injection risk and open files through their default associated app more safely.
  * Kept existing error handling and behavior unchanged for other platforms.
* **Documentation**
  * Added a note describing the Windows file-opening security issue and the recommended safe approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->