### PR TITLE
🎨 Palette: Improve TUI discoverability and prevent keyboard traps

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-24 - Prevent terminal keyboard traps and improve prompt discoverability
+**Learning:** Terminal raw modes (`tty.setraw`) trap the Ctrl-C (`\x03`) interrupt byte, effectively creating a keyboard trap where users cannot natively exit the prompt. This breaks fundamental UX expectations. Additionally, generic prompt methods in TUI libraries often obscure available options if choices aren't explicitly formatted into the prompt string.
+**Action:** Always explicitly read and map the `\x03` byte to `KeyboardInterrupt` when building custom raw input loops. For prompts falling back to standard input, explicitly format choices into the prompt text to maintain discoverability without breaking case-insensitive fallback logic.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -27,6 +27,8 @@ class TerminalUI:
                 return 'enter'
             if key == '\x1b':
                 return 'escape'
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
             return key
 
         import termios
@@ -43,6 +45,8 @@ class TerminalUI:
                 return mapping.get(next_chars, 'escape')
             if key in ('\r', '\n'):
                 return 'enter'
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
             return key
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
@@ -67,7 +71,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = help_text or 'Use Up/Down arrows and Enter to select (Esc/Ctrl-C to cancel).'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +80,8 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            choices_str = '|'.join(options)
+            answer = Prompt.ask(f"{title} \\[{choices_str}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
- **💡 What:** Explicitly handled the `\x03` interrupt byte to fix a keyboard trap, appended explicit shortcut hints `(Esc/Ctrl-C to cancel)` to the TUI footer, and exposed available options directly in the non-TTY fallback prompt string.
- **🎯 Why:** Users were unable to use the standard Ctrl-C shortcut to exit TUI selection dialogs, creating a keyboard trap. Additionally, non-interactive mode prompts failed to communicate valid options to users, reducing discoverability.
- **📸 Before/After:** Before: Users could not exit via Ctrl-C in raw mode, and prompts showed "Mode:" without options. After: Users can gracefully exit with Ctrl-C, and prompts show "Mode \[code|chat|script|command|vision]:".
- **♿ Accessibility:** Eliminated a severe keyboard trap and improved interface discoverability by making all available options explicitly visible to users interacting purely via terminal or screen readers.

---
*PR created automatically by Jules for task [15087703863219798551](https://jules.google.com/task/15087703863219798551) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer option prompts in non-terminal flows, showing valid choices directly in the question.
  * Improved selector messaging to include explicit cancel hints when no custom help text is shown.

* **Bug Fixes**
  * Ctrl-C now consistently cancels selection instead of getting trapped in raw input mode.
  * Selection cancellation behavior is now handled more reliably across different terminal environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->