### PR TITLE
🎨 Palette: Improve terminal UI keyboard navigation and inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-18 - Improve terminal UI affordances
+**Learning:** In terminal UI (TUI) environments, explicit prompts (e.g., choices, hint texts) are critical for intuitive UX because mouse affordances are missing. Explicitly raising KeyboardInterrupt on `\x03` prevents keyboard traps during raw input mode.
+**Action:** Always include keyboard hint strings (like Esc to cancel) and format option choices inline for headless prompt inputs. Handle interrupt signals directly.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -27,6 +27,8 @@ class TerminalUI:
                 return 'enter'
             if key == '\x1b':
                 return 'escape'
+            if key == '\x03':
+                raise KeyboardInterrupt
             return key
 
         import termios
@@ -43,6 +45,8 @@ class TerminalUI:
                 return mapping.get(next_chars, 'escape')
             if key in ('\r', '\n'):
                 return 'enter'
+            if key == '\x03':
+                raise KeyboardInterrupt
             return key
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
@@ -68,6 +72,7 @@ class TerminalUI:
             table.add_row(marker, label, style=style)
 
         footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer += ' (Esc/Ctrl-C to cancel)'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +81,8 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            choices_str = '|'.join(options)
+            answer = Prompt.ask(f"{title} \\[{choices_str}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
* 💡 What: Added inline choice display to fallback TUI prompts, explicitly trapped `\x03` (Ctrl-C) to prevent keyboard traps, and added Esc/Ctrl-C hints to the footer.
* 🎯 Why: Terminal UI lacks visual affordances; users need to know how to abort selections safely.
* 📸 Before/After: Before, `Prompt.ask` lacked options and TTY mode trapped Ctrl-C without aborting cleanly. Now, hints and options are visible and abort is clean.
* ♿ Accessibility: Improved keyboard accessibility and user orientation by providing explicit hints.

---
*PR created automatically by Jules for task [15652397196414331659](https://jules.google.com/task/15652397196414331659) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ctrl-C now cleanly cancels terminal input instead of being passed through, preventing keyboard traps in raw input mode.
  * The option selector now shows clearer cancellation guidance, including Esc/Ctrl-C.
  * Non-interactive prompts now display available choices more clearly in the prompt text.

* **Documentation**
  * Updated the terminal UI notes with guidance for clearer keyboard hints and headless input formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->