### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in Windows resource opener

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-25 - Prevent Windows Command Injection in Resource Opener
+**Vulnerability:** Command injection via `subprocess.call(['start', filename], shell=True)` on Windows when filename contains shell metacharacters (e.g., `&`). `os.path.isfile()` check does not prevent this because filenames can legally contain these characters.
+**Learning:** Using `shell=True` to open files on Windows is inherently unsafe with untrusted or complex filenames, even if the file exists.
+**Prevention:** Prefer `os.startfile(filename)` on Windows to safely launch files using their associated applications without invoking the shell.

--- a/libs/utility_manager.py
+++ b/libs/utility_manager.py
@@ -43,7 +43,8 @@ class UtilityManager:
 		try:
 			if os.path.isfile(filename):
 				if platform.system() == "Windows":
-					subprocess.call(['start', filename], shell=True)
+					# Security fix: Prevent command injection by avoiding shell=True
+					os.startfile(filename)
 				elif platform.system() == "Darwin":
 					subprocess.call(['open', filename])
 				elif platform.system() == "Linux":


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Command injection via `subprocess.call(['start', filename], shell=True)` on Windows. `os.path.isfile()` is insufficient protection because legal filenames can contain shell metacharacters like `&`.
🎯 Impact: An attacker could execute arbitrary system commands by providing a specially crafted filename.
🔧 Fix: Replaced `subprocess.call` using `shell=True` with `os.startfile(filename)` which safely launches files on Windows.
✅ Verification: Verified fix manually by inspecting code logic and ensuring the test suite passes.

---
*PR created automatically by Jules for task [15886942625122314513](https://jules.google.com/task/15886942625122314513) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file opening on Windows to avoid a command-injection risk when launching resources.
  * File paths are now opened more safely, while preserving the existing behavior for other platforms.

* **Documentation**
  * Added a security note describing the issue and the safer Windows approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->