### PR TITLE
🎨 Palette: [UX improvement] Add keyboard escape and options to terminal fallback UI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,7 @@
+## 2024-05-24 - Improve non-interactive fallback UI for prompts
+**Learning:** When using `Prompt.ask()` in `rich`, if options are not explicitly displayed to the user in a non-interactive/headless mode, the user won't know what choices are valid. This is particularly problematic in a CLI environment when `sys.stdin.isatty()` evaluates to `False`. The original code did `Prompt.ask(f"{title}", default=default_choice)`, leaving users blind to the choices.
+**Action:** Always format available choices into the prompt text when falling back to standard input, especially when bypassing `rich`'s strict `choices` validation (which we do to support custom case-insensitivity logic). Since `rich` interprets brackets as markup, we must escape them: `f"{title} \\[{'|'.join(options)}]"`.
+
+## 2024-05-24 - Prevent TUI keyboard traps in raw mode
+**Learning:** When reading bytes manually via `sys.stdin.read(1)` in raw TTY mode (e.g., inside `_read_key`), standard interrupt signals like `Ctrl+C` (`\x03`) do not automatically raise `KeyboardInterrupt`. Without explicit handling, these bytes fall through to the default path or are swallowed, trapping the user in the selector loop.
+**Action:** In terminal UI environments reading raw bytes, explicitly check for common interrupt bytes (like `\x03` for `Ctrl+C` and `\x04` for `Ctrl+D`) and either raise `KeyboardInterrupt` or map them to the UI's internal 'escape' / cancel action.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -27,6 +27,8 @@ class TerminalUI:
                 return 'enter'
             if key == '\x1b':
                 return 'escape'
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
             return key
 
         import termios
@@ -43,6 +45,8 @@ class TerminalUI:
                 return mapping.get(next_chars, 'escape')
             if key in ('\r', '\n'):
                 return 'enter'
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
             return key
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
@@ -76,7 +80,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
💡 What: Added choices to standard input fallback prompt and Ctrl-C escape in raw TUI mode.
🎯 Why: Improves intuitiveness of CLI fallback without TTY and removes a keyboard trap during selection.
📸 Before/After: Before, pressing Ctrl-C in raw TUI mode trapped users, and non-TTY prompted like "Mode (code): ". After, Ctrl-C acts as cancel, and fallback looks like "Mode [code|chat|script] (code): ".
♿ Accessibility: Keyboard navigation improvement by removing Ctrl-C trap.

---
*PR created automatically by Jules for task [3079405512322289142](https://jules.google.com/task/3079405512322289142) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard handling in terminal prompts so **Ctrl+C** now cancels immediately instead of getting stuck in some interactive flows.
  * Updated non-interactive prompts to show the available choices inline, making it clearer what input is accepted.
  * Reduced the risk of keyboard traps in raw terminal mode by handling interrupt-style input more safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->