### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing timeout in package manager requests

### DIFF
--- a/libs/package_manager.py
+++ b/libs/package_manager.py
@@ -173,7 +173,7 @@ class PackageManager:
 		try:
 			api_url = f"https://pypi.org/pypi/{package_name}/json"
 			self.logger.info("API Url is {}".format(api_url))
-			response = requests.get(api_url)
+			response = requests.get(api_url, timeout=10)
 			if response.status_code == 200:
 				return True
 			else:
@@ -186,7 +186,7 @@ class PackageManager:
 		
 	def _check_package_exists_npm(self,  package_name):
 		try:
-			response = requests.get(f"https://registry.npmjs.org/{package_name}")
+			response = requests.get(f"https://registry.npmjs.org/{package_name}", timeout=10)
 			if response.status_code == 200:
 				self.logger.info(f"Package {package_name} exists on npm registry")
 				return True


### PR DESCRIPTION
- 🚨 Severity: MEDIUM
- 💡 Vulnerability: Missing timeout on `requests.get` calls to PyPI and NPM registries.
- 🎯 Impact: Potential Denial of Service (DoS) if the external registry hangs, causing the application to hang indefinitely.
- 🔧 Fix: Added a `timeout=10` parameter to `requests.get()` calls in `libs/package_manager.py`.
- ✅ Verification: Run `python3 -m pytest tests/` and verify tests pass.

---
*PR created automatically by Jules for task [1115472296643820558](https://jules.google.com/task/1115472296643820558) started by @haseeb-heaven*