### PR TITLE
🎨 Palette: [UX improvement] Fix keyboard trap and improve prompt choices in TUI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-20 - Terminal Keyboard Trap and Prompt Clarity
+**Learning:** Terminal-based user interfaces often inadvertently create keyboard traps if standard interrupt bytes (like `\x03` for Ctrl-C) are handled identically to regular text inputs during raw mode execution, breaking basic application exit expectations. Also, missing explicit choice displays in fallback prompt views (`rich.prompt`) removes discoverability.
+**Action:** Always map terminal control characters (e.g., `\x03` for Ctrl-C) to explicit `KeyboardInterrupt` handling to prevent keyboard traps. Explicitly pass choices in prompt strings when fallback to text-mode prompts is used.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -27,6 +27,8 @@ class TerminalUI:
                 return 'enter'
             if key == '\x1b':
                 return 'escape'
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
             return key
 
         import termios
@@ -43,6 +45,8 @@ class TerminalUI:
                 return mapping.get(next_chars, 'escape')
             if key in ('\r', '\n'):
                 return 'enter'
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
             return key
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
@@ -76,7 +80,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
`💡 What`: Added `\x03` (Ctrl-C) handling to `_read_key` to explicitly raise `KeyboardInterrupt` and modified `Prompt.ask` to explicitly format options in the prompt string.
`🎯 Why`: Users could get stuck in the terminal menu (keyboard trap) when hitting Ctrl-C, and fallback prompts lacked visible choices, reducing discoverability.
`📸 Before/After`: N/A (terminal interaction changes)
`♿ Accessibility`: Removed keyboard trap and improved screen reader/fallback discoverability of choices.

---
*PR created automatically by Jules for task [9234208049847348989](https://jules.google.com/task/9234208049847348989) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ctrl+C now cleanly cancels terminal selections instead of being treated as a normal keypress.
  * Non-interactive prompts now clearly show the available choices, making fallback input easier to understand.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->