### PR TITLE
🎨 Palette: [UX improvement] Add explicit prompt choices, shortcut hints, and resolve TUI keyboard trap

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Translating Web UX to Terminal UI
+**Learning:** In terminal UIs, web UX concepts translate to explicit text formats: missing visual choices (dropdowns) require manual prompt choices (e.g., `\\[a|b|c]`), implicit escape actions need explicit visual hints ('Esc/Ctrl-C to cancel'), and handling keyboard traps requires raising exceptions for interrupt bytes (`\x03`) in raw mode.
+**Action:** Always provide explicit visual choices, explicit escape hints, and map standard interrupt bytes appropriately in TUI apps to maintain an intuitive and accessible UX.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -19,6 +19,8 @@ class TerminalUI:
         if os.name == 'nt':
             import msvcrt
             key = msvcrt.getwch()
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
             if key in ('\x00', '\xe0'):
                 extended = msvcrt.getwch()
                 mapping = {'H': 'up', 'P': 'down', 'K': 'left', 'M': 'right'}
@@ -37,6 +39,8 @@ class TerminalUI:
         try:
             tty.setraw(fd)
             key = sys.stdin.read(1)
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
             if key == '\x1b':
                 next_chars = sys.stdin.read(2)
                 mapping = {'[A': 'up', '[B': 'down', '[D': 'left', '[C': 'right'}
@@ -67,7 +71,8 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        base_footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = f"{base_footer} (Ctrl-C to cancel)"
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +81,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
💡 What: Added explicit prompt choices for non-TTY environments, explicit shortcut hints in the TUI footer, and resolved a keyboard trap by explicitly raising `KeyboardInterrupt` on Ctrl-C (`\x03`) in raw mode.
🎯 Why: Makes the interface more intuitive by clearly showing available choices and how to exit, and prevents users from being trapped in the TUI when pressing Ctrl-C.
📸 Before/After: Before, non-TTY prompts lacked options, TUI lacked escape hints, and Ctrl-C was ignored in raw mode. After, explicit choices are shown, hints are added, and Ctrl-C correctly exits.
♿ Accessibility: Improves cognitive accessibility by providing clear textual hints and options, and prevents keyboard traps for users navigating exclusively via keyboard.

---
*PR created automatically by Jules for task [2750797255425457407](https://jules.google.com/task/2750797255425457407) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer terminal selection prompts that show available choices in the question itself.
  * Displayed an explicit “Ctrl-C to cancel” hint in selector help text.

* **Bug Fixes**
  * Improved cancel handling so pressing Ctrl-C now exits selection cleanly instead of being treated like a normal input.
  * Made cancellation behavior consistent across terminal environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->