### PR TITLE
🎨 Palette: [UX improvement] Display options in headless TUI prompts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Display explicit options in headless TUI prompts
+**Learning:** Headless fallback prompts relying on default fallback behavior without displaying options can trap users. Showing choices explicitly improves accessibility and usability in non-TTY environments.
+**Action:** When creating text-based prompts that fallback to standard input matching, always format the available options visibly within the prompt string.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -76,7 +76,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
🎨 Palette: [UX improvement]
💡 What: Added visible options to headless prompts in `TerminalUI._select_option`
🎯 Why: When `sys.stdin.isatty()` is False, users could only guess what inputs are available.
📸 Before/After: Before `Mode`, After `Mode \[code|chat|script|command|vision]`
♿ Accessibility: Improves usability for those in restricted terminal environments.

---
*PR created automatically by Jules for task [10128039033244917033](https://jules.google.com/task/10128039033244917033) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Non-interactive prompts now show the available choices directly in the prompt text, making headless input easier to understand and use.
* **Documentation**
  * Added a brief note with guidance for displaying explicit options when falling back to standard input matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->