### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing timeout configurations

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-27 - Missing Timeouts in API Calls
+**Vulnerability:** External API calls via the `requests` library lacked a `timeout` parameter.
+**Learning:** This exposes the application to a Denial of Service (DoS) vulnerability where a slow or unresponsive external server can cause the application thread to hang indefinitely.
+**Prevention:** Always specify an explicit `timeout` parameter (e.g., `timeout=10`) when using `requests.get` or `requests.post`.

--- a/libs/package_manager.py
+++ b/libs/package_manager.py
@@ -173,7 +173,7 @@ class PackageManager:
 		try:
 			api_url = f"https://pypi.org/pypi/{package_name}/json"
 			self.logger.info("API Url is {}".format(api_url))
-			response = requests.get(api_url)
+			response = requests.get(api_url, timeout=10)
 			if response.status_code == 200:
 				return True
 			else:
@@ -186,7 +186,7 @@ class PackageManager:
 		
 	def _check_package_exists_npm(self,  package_name):
 		try:
-			response = requests.get(f"https://registry.npmjs.org/{package_name}")
+			response = requests.get(f"https://registry.npmjs.org/{package_name}", timeout=10)
 			if response.status_code == 200:
 				self.logger.info(f"Package {package_name} exists on npm registry")
 				return True

--- a/libs/utility_manager.py
+++ b/libs/utility_manager.py
@@ -318,7 +318,7 @@ class UtilityManager:
 			logger = Logger.initialize("logs/interpreter.log")
 			import requests
 			logger.info(f"Downloading file: {url}")
-			response = requests.get(url, allow_redirects=True)
+			response = requests.get(url, allow_redirects=True, timeout=10)
 			response.raise_for_status()
 			
 			with open(file_name, 'wb') as file:


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix missing timeout configurations

🚨 Severity: MEDIUM
💡 Vulnerability: Missing `timeout` argument in `requests.get` calls in `libs/package_manager.py` and `libs/utility_manager.py`.
🎯 Impact: An unresponsive external server could cause the program to hang indefinitely, leading to a Denial of Service.
🔧 Fix: Added `timeout=10` parameter to all `requests.get` calls.
✅ Verification: Verified using `read_file` and ran the full test suite using `python3 -m pytest tests/`.

---
*PR created automatically by Jules for task [11757921596059022278](https://jules.google.com/task/11757921596059022278) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added time limits to network requests so package checks and downloads won’t hang indefinitely.
  * Improved reliability when contacting external registries and downloading files, reducing the risk of stalled operations.
* **Chores**
  * Added an internal note documenting the timeout requirement for outbound HTTP requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->