### PR TITLE
🎨 Palette: [UX improvement] Improve TUI Keyboard Accessibility and Hinting

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-30 - TUI Keyboard Traps and Hinting
+**Learning:** In raw terminal UI environments, standard interrupt bytes like `\x03` (Ctrl-C) are not automatically translated into `KeyboardInterrupt`. This creates a keyboard trap where users cannot gracefully cancel out of interactive menus. Furthermore, without explicit UI hints, users don't know how to cancel.
+**Action:** Always intercept standard interrupt bytes in raw terminal mode and explicitly raise `KeyboardInterrupt`, and ensure footer hints explicitly mention how to cancel (e.g. 'Ctrl-C to cancel') to ensure an accessible, frustration-free TUI experience.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -37,6 +37,8 @@ class TerminalUI:
         try:
             tty.setraw(fd)
             key = sys.stdin.read(1)
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
             if key == '\x1b':
                 next_chars = sys.stdin.read(2)
                 mapping = {'[A': 'up', '[B': 'down', '[D': 'left', '[C': 'right'}
@@ -67,7 +69,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = help_text or 'Use Up/Down arrows and Enter to select, Ctrl-C to cancel.'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +78,8 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            escaped_options = "\\[" + "|".join(options) + "]"
+            answer = Prompt.ask(f"{title} {escaped_options}", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
💡 What: Added explicit handling for Ctrl-C (`\x03`) in raw mode to raise `KeyboardInterrupt`, updated the TUI footer to hint 'Ctrl-C to cancel', and formatted fallback fallback prompts to show explicit options (escaping rich formatting).
🎯 Why: Users could be trapped in raw mode TUI without a way to exit. Adding a clear hint and intercepting standard interrupt bytes makes the TUI accessible and frustration-free. The fallback mode prompts were missing choice indicators.
📸 Before/After: Before: Users pressing Ctrl-C got stuck, footer only mentioned arrows. After: Ctrl-C gracefully cancels, footer explicitly says 'Ctrl-C to cancel'.
♿ Accessibility: Resolves a keyboard trap issue in raw terminal mode and improves discoverability of cancel operations.

---
*PR created automatically by Jules for task [5663658388824319144](https://jules.google.com/task/5663658388824319144) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal prompts now show clearer option hints in non-interactive mode.
  * Default terminal help text now includes a visible “Ctrl-C to cancel” reminder.

* **Bug Fixes**
  * Improved handling of Ctrl-C in terminal input so cancellations work more reliably.
  * Added a clearer cancellation message when a selection is interrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->