### PR TITLE
🎨 Palette: [UX improvement] Improve TUI fallback prompts and cancellation hints

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-18 - Improve terminal UI accessibility and fallback inputs
+**Learning:** Terminal environments without TTYs require explicit choices in text prompts for intuitive headless usage. In raw mode TTYs, standard interrupt bytes (like `\x03`) must be explicitly handled, and keyboard shortcut hints in UI footers prevent keyboard traps.
+**Action:** Always provide explicitly listed options in plain text prompt fallbacks and include cancellation shortcut hints in TUI footers to ensure keyboard accessibility.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -68,6 +68,8 @@ class TerminalUI:
             table.add_row(marker, label, style=style)
 
         footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        if 'Ctrl-C' not in footer:
+            footer += ' (Ctrl-C to cancel)'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +78,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:
@@ -99,7 +101,7 @@ class TerminalUI:
                 selected_index = (selected_index + 1) % len(options)
             elif key == 'enter':
                 return options[selected_index]
-            elif key == 'escape':
+            elif key in ('escape', '\x03'):
                 raise KeyboardInterrupt('Selection cancelled by user.')
             elif isinstance(key, str) and len(key) == 1:
                 lowered = key.lower()


### PR DESCRIPTION
💡 What: Added inline choices to headless text prompts and a "(Ctrl-C to cancel)" hint to the TUI footer, alongside handling the explicit `\x03` byte in raw mode.
🎯 Why: Improves the intuitive use of fallback inputs when not in a TTY and prevents keyboard traps in raw TTY environments by providing clear cancellation hints.
📸 Before/After: Before, non-TTY input prompts lacked visible options and raw TTY modes lacked clear cancellation instructions. After, choices are visibly joined by `|` and `Ctrl-C` is advertised.
♿ Accessibility: Fixes a potential keyboard trap and improves discoverability of fallback prompt options.

---
*PR created automatically by Jules for task [6503636358884944520](https://jules.google.com/task/6503636358884944520) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer keyboard-friendly prompts for option selection in non-interactive environments.
  * Footer/help text now includes a visible “Ctrl-C to cancel” hint when needed.

* **Bug Fixes**
  * Improved cancellation handling so both Escape and Ctrl-C now cancel selection consistently.
  * Option prompts now show available choices inline when running without an interactive terminal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->