### PR TITLE
🎨 Palette: [UX] Improve TUI selection prompts and cancel interactions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - TUI Keyboard Traps and Prompt Clarity
+**Learning:** In terminal UIs using raw mode, advertising 'Esc' (\x1b) as a cancellation key can create a keyboard trap because the application subsequently blocks on sys.stdin.read(2) waiting for ANSI sequences (like arrow keys). Also, non-interactive fallback prompts must explicitly list valid choices to be accessible.
+**Action:** Explicitly advertise and map Ctrl-C (\x03) to KeyboardInterrupt for cancellations, and manually format explicit options directly into the prompt string using escaped brackets (e.g., \[a|b]) for rich Prompts.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -27,6 +27,8 @@ class TerminalUI:
                 return 'enter'
             if key == '\x1b':
                 return 'escape'
+            if key == '\x03':
+                return 'cancel'
             return key
 
         import termios
@@ -43,6 +45,8 @@ class TerminalUI:
                 return mapping.get(next_chars, 'escape')
             if key in ('\r', '\n'):
                 return 'enter'
+            if key == '\x03':
+                return 'cancel'
             return key
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
@@ -68,6 +72,7 @@ class TerminalUI:
             table.add_row(marker, label, style=style)
 
         footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer += ' Ctrl-C to cancel.'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +81,8 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            options_str = '|'.join(options)
+            answer = Prompt.ask(f"{title} \\[{options_str}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:
@@ -99,7 +105,7 @@ class TerminalUI:
                 selected_index = (selected_index + 1) % len(options)
             elif key == 'enter':
                 return options[selected_index]
-            elif key == 'escape':
+            elif key in ('escape', 'cancel'):
                 raise KeyboardInterrupt('Selection cancelled by user.')
             elif isinstance(key, str) and len(key) == 1:
                 lowered = key.lower()


### PR DESCRIPTION
💡 What: Added explicit "Ctrl-C to cancel" shortcut hints in the TUI, mapped \x03 to cancel properly, and explicitly formatted valid prompt choices in headless fallback modes.
🎯 Why: Using "Esc" as a cancel key in raw terminal mode causes a blocking keyboard trap (waiting for ANSI sequence completion). Additionally, the non-tty fallback prompts did not show valid choices, leaving users guessing.
📸 Before/After: N/A
♿ Accessibility: Fixes a keyboard trap issue and improves prompt clarity.

---
*PR created automatically by Jules for task [15694068063560762363](https://jules.google.com/task/15694068063560762363) started by @haseeb-heaven*