### PR TITLE
🎨 Palette: Improve terminal UX accessibility with visible prompts and explicit cancel hints

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-01-01 - TUI Shortcuts and Visual Prompts
+**Learning:** In headless terminal environments, web-style visual affordances must be explicitly surfaced (e.g., manually formatting options in `rich` prompts without triggering markup parsing). Furthermore, 'Esc' (`\x1b`) should never be advertised as a TUI cancel action in raw mode, as blocking ANSI escape sequence reads can hang the app.
+**Action:** Always manually escape choice formatting in `rich` prompts (e.g., `\[a|b]`), use `\x03` (`Ctrl-C`) for TUI cancellation, and append shortcut hints to footer text.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -19,6 +19,8 @@ class TerminalUI:
         if os.name == 'nt':
             import msvcrt
             key = msvcrt.getwch()
+            if key == '\x03':
+                raise KeyboardInterrupt
             if key in ('\x00', '\xe0'):
                 extended = msvcrt.getwch()
                 mapping = {'H': 'up', 'P': 'down', 'K': 'left', 'M': 'right'}
@@ -37,6 +39,8 @@ class TerminalUI:
         try:
             tty.setraw(fd)
             key = sys.stdin.read(1)
+            if key == '\x03':
+                raise KeyboardInterrupt
             if key == '\x1b':
                 next_chars = sys.stdin.read(2)
                 mapping = {'[A': 'up', '[B': 'down', '[D': 'left', '[C': 'right'}
@@ -67,7 +71,8 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        base_footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = f"{base_footer} (Ctrl-C to cancel)"
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +81,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
💡 What: Added explicit keyboard cancel hints (`Ctrl-C to cancel`), gracefully handled `\x03` keystrokes to prevent keyboard traps, and surfaced available choices explicitly in headless inputs.
🎯 Why: To prevent terminal hangs from missing `Esc` ANSI sequences, give users explicit visual affordances for prompts, and provide a clear, reliable path to exit.
📸 Before/After: Before, non-interactive prompts didn't list options, and `Esc` caused hangs. After, choices are explicitly visible `[code|chat|...]` and `Ctrl-C` is properly handled.
♿ Accessibility: Improved terminal-equivalent accessibility by surfacing explicit keyboard shortcuts, avoiding keyboard traps, and clearly displaying available input choices.

---
*PR created automatically by Jules for task [3787583290221606918](https://jules.google.com/task/3787583290221606918) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved terminal prompts to show available options more clearly in non-interactive environments.
  * Added visible shortcut guidance to selector footers, including a cancel hint.

* **Bug Fixes**
  * Ctrl-C now cancels immediately and consistently in terminal input on both Windows and POSIX systems.
  * Clarified prompt behavior for raw terminal mode so cancel actions are shown correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->