### PR TITLE
🎨 Palette: Add TUI Keyboard Traps and Prompt Choices

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-04 - Terminal UI Keyboard Traps
+**Learning:** In terminal raw mode (TTY), reading standard escape sequences natively intercepts `\x03` (Ctrl-C) as standard text, causing keyboard traps.
+**Action:** When handling raw input, explicitly catch the `\x03` byte and raise `KeyboardInterrupt` to ensure users can exit the interface, and update prompt messages to explicitly inform the user of standard exit choices like "Ctrl-C to cancel" rather than "Esc" to prevent sequence hanging.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -27,6 +27,8 @@ class TerminalUI:
                 return 'enter'
             if key == '\x1b':
                 return 'escape'
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
             return key
 
         import termios
@@ -37,6 +39,8 @@ class TerminalUI:
         try:
             tty.setraw(fd)
             key = sys.stdin.read(1)
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
             if key == '\x1b':
                 next_chars = sys.stdin.read(2)
                 mapping = {'[A': 'up', '[B': 'down', '[D': 'left', '[C': 'right'}
@@ -67,7 +71,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = help_text or 'Use Up/Down arrows and Enter to select. Ctrl-C to cancel.'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +80,8 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            options_str = '|'.join(str(opt) for opt in options)
+            answer = Prompt.ask(f"{title} \\[{options_str}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
🎨 Palette: Add TUI Keyboard Traps and Prompt Choices

💡 What: Added explicit prompt choices when running in non-TTY mode, added a `Ctrl-C to cancel` indicator in TUI selector panel, and fixed a keyboard trap where `Ctrl-C` would be read natively without triggering `KeyboardInterrupt` in raw mode.
🎯 Why: To ensure users are not locked in raw terminal mode when standard abort keys are used, and to show explicit valid options for configuration inputs.
📸 Before/After: Visual hints added for cancelability.
♿ Accessibility: Preventing keyboard traps is a critical a11y consideration; ensuring users have a visible exit path and the TUI handles standard interrupt sequences.

---
*PR created automatically by Jules for task [13538077490241913394](https://jules.google.com/task/13538077490241913394) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ctrl-C now cancels terminal selections consistently instead of being treated as typed input.
  * Updated the selector footer to clearly show “Ctrl-C to cancel,” reducing confusion in keyboard navigation.
  * Improved non-interactive prompts to include the available options directly in the prompt text, making selections clearer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->