### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in resource opener

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-05 - Windows Command Injection via subprocess.call
+**Vulnerability:** Command Injection vulnerability exists when using `subprocess.call(['start', filename], shell=True)` because `shell=True` on Windows allows attackers to execute arbitrary shell commands if the filename contains shell metacharacters (e.g. `&` or `^`), even if it passes `os.path.isfile()`.
+**Learning:** Checking if a file exists (`os.path.isfile()`) is insufficient to prevent command injection on Windows when `shell=True` is used, because legal Windows filenames can contain metacharacters that the shell interprets.
+**Prevention:** Always prefer `os.startfile(filename)` over `subprocess.call` with `shell=True` for opening files on Windows.

--- a/libs/utility_manager.py
+++ b/libs/utility_manager.py
@@ -43,7 +43,7 @@ class UtilityManager:
 		try:
 			if os.path.isfile(filename):
 				if platform.system() == "Windows":
-					subprocess.call(['start', filename], shell=True)
+					os.startfile(filename)
 				elif platform.system() == "Darwin":
 					subprocess.call(['open', filename])
 				elif platform.system() == "Linux":


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix command injection in resource opener

🚨 Severity: CRITICAL
💡 Vulnerability: Command injection on Windows when opening files via subprocess.call with shell=True. Even though `os.path.isfile` is checked, valid filenames on Windows can contain shell metacharacters (e.g. `&` and `^`), meaning an attacker who creates such a file or controls the filename parameter could execute arbitrary commands.
🎯 Impact: Arbitrary code execution if an attacker supplies a malicious file name.
🔧 Fix: Replaced `subprocess.call(['start', filename], shell=True)` with secure native API `os.startfile(filename)`.
✅ Verification: Ran python tests and verified no regressions. Verified that files open securely on Windows environments natively without shell interpretation.

---
*PR created automatically by Jules for task [4285252108870944537](https://jules.google.com/task/4285252108870944537) started by @haseeb-heaven*