### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in Windows file launch

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-30 - Command Injection in Windows File Launch
+**Vulnerability:** \`subprocess.call(['start', filename], shell=True)\` was used to open files on Windows, allowing arbitrary command execution if the filename contained shell metacharacters like \`&\` or \`^\`.
+**Learning:** \`os.path.isfile()\` verification is insufficient to prevent command injection because Windows filenames can legally contain shell metacharacters.
+**Prevention:** Use \`os.startfile()\` which executes the file natively without invoking \`cmd.exe\`.

--- a/libs/utility_manager.py
+++ b/libs/utility_manager.py
@@ -43,7 +43,8 @@ class UtilityManager:
 		try:
 			if os.path.isfile(filename):
 				if platform.system() == "Windows":
-					subprocess.call(['start', filename], shell=True)
+					# 🛡️ Sentinel: Prevent command injection by avoiding shell=True for file execution
+					os.startfile(filename)
 				elif platform.system() == "Darwin":
 					subprocess.call(['open', filename])
 				elif platform.system() == "Linux":


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Used `subprocess.call` with `shell=True` to open files on Windows. If a filename contained metacharacters (e.g. `file&calc.exe`), it could lead to arbitrary command execution despite `os.path.isfile` checks.
🎯 Impact: A malicious actor could trick a user or system into opening a specially crafted file, executing arbitrary commands on the host machine.
🔧 Fix: Replaced `subprocess.call` with `os.startfile(filename)` to natively launch the file without a shell. Added a security comment.
✅ Verification: Run the test suite and flake8 linter. Ensure `libs/utility_manager.py` accurately contains the `os.startfile()` modification.

---
*PR created automatically by Jules for task [4436699916890072166](https://jules.google.com/task/4436699916890072166) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved how files are opened on Windows to avoid command-injection risks.
  - Replaced a shell-based file launch approach with a safer native file-opening method.
  - Added a note clarifying that basic file-existence checks are not enough to make this operation safe on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->