### PR TITLE
🎨 Palette: [UX improvement] Improve TUI accessibility with explicit prompt choices and keyboard trap fixes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-07-06 - Terminal UI Accessibility and Keyboard Traps
+**Learning:** In raw mode, standard interrupt bytes like \x03 (Ctrl-C) are swallowed by read functions and do not trigger KeyboardInterrupt, creating keyboard traps for users. Advertising "Esc" as a cancel action also causes hangs due to partial ANSI sequence matching.
+**Action:** Always explicitly trap and handle \x03 to raise KeyboardInterrupt in raw mode loops, explicitly document "Ctrl-C to cancel" in TUI footer hints, and explicitly format available choices into non-interactive fallback prompts using escaped brackets like \[A|B] for clear visibility.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -67,7 +67,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = help_text or 'Use Up/Down arrows and Enter to select. Ctrl-C to cancel.'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -76,7 +76,8 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            options_str = '|'.join(options)
+            answer = Prompt.ask(f"{title} \\[{options_str}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:
@@ -99,7 +100,7 @@ class TerminalUI:
                 selected_index = (selected_index + 1) % len(options)
             elif key == 'enter':
                 return options[selected_index]
-            elif key == 'escape':
+            elif key in ('escape', '\x03'):
                 raise KeyboardInterrupt('Selection cancelled by user.')
             elif isinstance(key, str) and len(key) == 1:
                 lowered = key.lower()
@@ -110,7 +111,7 @@ class TerminalUI:
 
     def _select_boolean(self, title, default=False):
         default_choice = 'yes' if default else 'no'
-        choice = self._select_option(title, ['yes', 'no'], default_choice, 'Use Up/Down arrows and Enter to choose.')
+        choice = self._select_option(title, ['yes', 'no'], default_choice, 'Use Up/Down arrows and Enter to choose. Ctrl-C to cancel.')
         return choice == 'yes'
 
     def select_mode(self, default_mode='code'):
@@ -121,7 +122,7 @@ class TerminalUI:
         default_model = default_model or self.utility_manager.get_default_model_name()
         if default_model not in models:
             default_model = models[0]
-        return self._select_option('Model', models, default_model, 'Use Up/Down arrows, Enter, or type the first letter to jump.')
+        return self._select_option('Model', models, default_model, 'Use Up/Down arrows, Enter, or type the first letter to jump. Ctrl-C to cancel.')
 
     def select_language(self, default_lang='python'):
         return self._select_option('Language', ['python', 'javascript'], default_lang)


### PR DESCRIPTION
💡 What: Added explicit prompt choices formatted with escaped brackets to non-interactive inputs, appended clear "Ctrl-C to cancel" shortcuts to TUI hints, and explicitly handled `\x03` to raise `KeyboardInterrupt` instead of creating a keyboard trap.
🎯 Why: To make the terminal interface more accessible and prevent users from getting stuck in raw TUI mode without a clear way to cancel.
📸 Before/After: Before, non-interactive prompts didn't show options, and Ctrl-C in interactive mode failed to cancel. After, options are clearly visible and Ctrl-C behaves as expected without hanging.
♿ Accessibility: Fixes a severe keyboard trap by properly parsing the `\x03` interrupt byte in raw TUI modes, and improves non-visual screen-reader context by appending explicit TUI hint texts for navigation and cancellation.

---
*PR created automatically by Jules for task [2032521934654734485](https://jules.google.com/task/2032521934654734485) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved terminal prompts by showing the available choices more clearly.
  * Updated on-screen guidance to include keyboard navigation and cancel options.

* **Bug Fixes**
  * Fixed cancel behavior so both **Esc** and **Ctrl-C** now exit selection cleanly.
  * Reduced the chance of the terminal getting stuck during interactive selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->