### PR TITLE
🎨 Palette: Show prompt choices when fallback prompts are used

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-08 - Displaying choices in Rich prompts without breaking case-insensitivity
+**Learning:** When using `rich.prompt.Prompt.ask()`, providing the `choices` argument enforces strict, case-sensitive input matching which overrides custom case-insensitivity logic. Additionally, to manually format the choices into the prompt string, brackets must be escaped as `\\[` to prevent `rich` from incorrectly parsing them as markup and to avoid Python syntax warnings.
+**Action:** When we need to show choices but still allow custom validation (like case-insensitivity), format the choices directly into the prompt string and escape the brackets.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -76,7 +76,7 @@ class TerminalUI:
     def _select_option(self, title, options, default, help_text=None):
         if not sys.stdin.isatty():
             default_choice = default if default in options else options[0]
-            answer = Prompt.ask(f"{title}", default=default_choice).strip()
+            answer = Prompt.ask(f"{title} \\[{'|'.join(options)}]", default=default_choice).strip()
             if answer in options:
                 return answer
             for option in options:


### PR DESCRIPTION
💡 What: Manually formatting choices in the Prompt.ask call in non-TTY environments.
🎯 Why: Rich's `choices` argument enforces strict case-sensitive checks. To allow our custom validation logic, it had been removed, but this also hid the available options from the prompt.
📸 Before/After: Before: `Mode (yes):` After: `Mode [yes|no] (yes):`
♿ Accessibility: Ensures that users always know what options are available, even when the interface falls back to a non-interactive prompt in CI/scripting scenarios.

---
*PR created automatically by Jules for task [15688149336573428950](https://jules.google.com/task/15688149336573428950) started by @haseeb-heaven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Non-interactive prompts now show the available choices directly in the message, making it clearer which option will be selected.
* **Bug Fixes**
  * Improved prompt formatting so choice lists display correctly without parsing issues or warning messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->