### PR TITLE
Set up Cursor Cloud dev environment (venv, lint, tests, end-to-end run)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Open Code Interpreter is a **single-product, terminal-based Python CLI/TUI** (no web server, no
+database). It turns natural-language tasks into code and executes it in a sandbox. It talks to
+external LLM providers over HTTP; there is nothing long-running to "start" besides the CLI itself.
+
+### Environment
+- Python dependencies live in a virtualenv at `.venv` (gitignored). The startup update script keeps
+  it in sync with `requirements.txt`. Activate it with `source .venv/bin/activate` (or call
+  `.venv/bin/python` directly) before running any command below.
+- Runtime is Python 3.12 here; upstream CI (`.github/workflows/python-app.yml`) pins 3.10. Both work.
+- A `.env` file is required at the repo root for the app to start (it is gitignored). Copy it from
+  `.env.example` and populate at least one provider key. `initialize_client` validates a key even for
+  the `local-model` config (it falls through to the HuggingFace check because the config's `model`
+  value is `llama3.1:8b`, which does not contain the string "local"), so a placeholder
+  `HUGGINGFACE_API_KEY=hf_...` plus `OPENAI_API_KEY=sk-...` is enough to reach the local endpoint.
+
+### Lint / Test (no external services needed)
+- Lint: `flake8 . --select=E9,F63,F7,F82 --show-source --exclude=.venv` (fatal errors only, as CI does).
+- Tests: `python -m unittest discover -s tests` — 252 tests, all provider calls are mocked, so no live
+  API keys or network are required. `pytest` also works.
+- Some passing tests intentionally print argparse `usage:`/error text and `SyntaxWarning` lines to the
+  console; that output is expected and does not indicate failure.
+
+### Running the app end-to-end without cloud API keys
+The documented "offline model" flow (README → *Offline models setup*) points `configs/local-model.json`
+at an OpenAI-compatible endpoint (`api_base`, default `http://localhost:11434/v1`), i.e. LM Studio /
+Ollama / vLLM. In this environment there are no provider keys and no Ollama, so end-to-end runs use a
+tiny local OpenAI-compatible stub server that returns a fenced code block. The interpreter's real
+pipeline (litellm dispatch → HTTP → response parse → code extraction → sandbox execution) runs
+unchanged against it.
+
+- The CLI is non-interactive-friendly: pipe the task, then `y` to approve execution, then `/exit`, e.g.
+  `printf 'print hello world\ny\n/exit\n' | python interpreter.py --cli -m local-model -md code -dc`.
+- Default mode is SAFE MODE (sandboxed); dangerous file ops are blocked outright. Use `--no-sandbox`
+  only for trusted local runs.
+- `python interpreter.py` with no args launches the arrow-key TUI (needs a real TTY); prefer `--cli`
+  for scripted/automated runs.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for **Open Code Interpreter** (a single-product Python CLI/TUI; no web server or database) and demonstrates it running end-to-end.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section documenting durable, non-obvious setup/run caveats (venv location, `.env` requirement + the `local-model` key-validation quirk, lint/test commands, and the offline-model end-to-end run flow).
- Configures the startup update script to keep the `.venv` in sync with `requirements.txt` (`python3 -m venv .venv`; `pip install -r requirements.txt flake8`).

No application code was modified. `.venv` and `.env` are gitignored, so only `AGENTS.md` is committed.

## Environment

- Python 3.12 in a `.venv` virtualenv (installed `python3.12-venv` system package). Upstream CI pins 3.10; both work.
- Dependencies installed from `requirements.txt` plus `flake8`.
- `.env` created from `.env.example` with placeholder keys (gitignored).

## End-to-end verification

There are no cloud provider keys or Ollama in this environment, so the documented offline-model flow (README → *Offline models setup*, `configs/local-model.json` → OpenAI-compatible `api_base`) was exercised against a tiny local OpenAI-compatible stub server. The interpreter's real pipeline (litellm dispatch → HTTP → response parse → code extraction → SAFE MODE sandbox execution) ran unchanged and produced live output.

[interpreter_cli_hello_world_demo.mp4](https://cursor.com/agents/bc-51849831-423f-474c-b018-5466c392cbb2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finterpreter_cli_hello_world_demo.mp4)

Task `print a hello world message and the sum of 1 to 10` → generated Python code → executed → `Hello World from Open Code Interpreter!` / `Sum of 1..10 = 55`.

[Interpreter CLI final output](https://cursor.com/agents/bc-51849831-423f-474c-b018-5466c392cbb2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finterpreter_cli_final_output.webp)

## Testing

- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude=.venv` — 0 issues
- `python -m unittest discover -s tests` — 252 tests, all pass (provider calls mocked; no keys/network needed)
- End-to-end CLI run against local model — see video/screenshot above


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51849831-423f-474c-b018-5466c392cbb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51849831-423f-474c-b018-5466c392cbb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup and development guidance for the project.
  * Documented virtual environment configuration, environment variables, linting, testing, and end-to-end workflows.
  * Added instructions for offline operation, command-line usage, safety modes, and terminal interface requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->