### PR TITLE
test: smoke matrix for all 68 models + ModelRouter local/OpenRouter auth fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,10 +12,10 @@ external LLM providers over HTTP; there is nothing long-running to "start" besid
   `.venv/bin/python` directly) before running any command below.
 - Runtime is Python 3.12 here; upstream CI (`.github/workflows/python-app.yml`) pins 3.10. Both work.
 - A `.env` file is required at the repo root for the app to start (it is gitignored). Copy it from
-  `.env.example` and populate at least one provider key. `initialize_client` validates a key even for
-  the `local-model` config (it falls through to the HuggingFace check because the config's `model`
-  value is `llama3.1:8b`, which does not contain the string "local"), so a placeholder
-  `HUGGINGFACE_API_KEY=hf_...` plus `OPENAI_API_KEY=sk-...` is enough to reach the local endpoint.
+  `.env.example` and populate at least one provider key. Local configs with
+  `provider: local|ollama|lmstudio` skip cloud key checks (ModelRouter). For a stub local server,
+  `OPENAI_API_KEY=sk-...` is enough. Live smoke across cloud providers needs the matching
+  `*_API_KEY` values (`SMOKE_LIVE=1 python scripts/smoke_all_models.py`).
 
 ### Lint / Test (no external services needed)
 - Lint: `flake8 . --select=E9,F63,F7,F82 --show-source --exclude=.venv` (fatal errors only, as CI does).
@@ -27,6 +27,10 @@ external LLM providers over HTTP; there is nothing long-running to "start" besid
   - Async (#203): `python -m unittest discover -s tests/async`
   - Memory (#204): `python -m unittest discover -s tests/memory`
   - Tools (#205): `python -m unittest discover -s tests/tools`
+  - All model configs (offline): `python -m unittest tests.test_all_model_configs` or
+    `python scripts/smoke_all_models.py`
+  - Live provider smoke (needs real keys): `SMOKE_LIVE=1 python scripts/smoke_all_models.py`
+  - Local mock smoke: `python -m unittest tests.smoke.test_local_model_smoke`
 - TestSprite backend suite (CLI only, no frontend):
   `python -m unittest discover -s testsprite_tests -p 'TC*.py' -v`
 - Some passing tests intentionally print argparse `usage:`/error text and `SyntaxWarning` lines to the

--- a/libs/core/model_router.py
+++ b/libs/core/model_router.py
@@ -50,8 +50,14 @@ class ModelRouter:
 		model_name = interp.INTERPRETER_MODEL.strip().split("/")[-1]
 
 		# skip init client for local models.(Bug#10)
-		if ("local" in interp.INTERPRETER_MODEL or "ollama" in interp.INTERPRETER_MODEL
-			or str(interp.config_values.get("provider", "")).strip().lower() == "ollama"):
+		# Prefer config provider so models like llama3.1:8b with provider=local skip HF key checks.
+		_local_providers = ("local", "ollama", "lmstudio")
+		_cfg_provider = str(interp.config_values.get("provider", "")).strip().lower()
+		if (
+			"local" in interp.INTERPRETER_MODEL
+			or "ollama" in interp.INTERPRETER_MODEL
+			or _cfg_provider in _local_providers
+		):
 			interp.logger.info("Skipping client initialization for local model.")
 			api_key = getenv_fn("OPENAI_API_KEY")
 
@@ -70,14 +76,21 @@ class ModelRouter:
 
 		config_provider = str(interp.config_values.get("provider", "")).strip().lower()
 
-		if config_provider == "nvidia" or interp.INTERPRETER_MODEL.startswith("nvidia/"):
+		# Provider field wins over model-id heuristics (OpenRouter may use nvidia/... ids).
+		if config_provider == "nvidia":
 			api_key_info = {"key_name": "NVIDIA_API_KEY", "prefix": "nvapi-"}
-		elif config_provider in ("z-ai", "zai") or interp.INTERPRETER_MODEL.startswith(("glm-", "z-ai/", "zai/")):
+		elif config_provider in ("z-ai", "zai"):
 			api_key_info = {"key_name": "Z_AI_API_KEY", "prefix": None, "length": 10}
-		elif config_provider in ("browser-use", "browser_use") or interp.INTERPRETER_MODEL.startswith(("bu-", "browser-use/")):
+		elif config_provider in ("browser-use", "browser_use"):
 			api_key_info = {"key_name": "BROWSER_USE_API_KEY", "prefix": "bu_"}
 		elif config_provider == "openrouter":
 			api_key_info = {"key_name": "OPENROUTER_API_KEY", "prefix": "sk-or-v1-"}
+		elif interp.INTERPRETER_MODEL.startswith("nvidia/"):
+			api_key_info = {"key_name": "NVIDIA_API_KEY", "prefix": "nvapi-"}
+		elif interp.INTERPRETER_MODEL.startswith(("glm-", "z-ai/", "zai/")):
+			api_key_info = {"key_name": "Z_AI_API_KEY", "prefix": None, "length": 10}
+		elif interp.INTERPRETER_MODEL.startswith(("bu-", "browser-use/")):
+			api_key_info = {"key_name": "BROWSER_USE_API_KEY", "prefix": "bu_"}
 		elif interp.INTERPRETER_MODEL.startswith(("gpt", "o1", "o3", "o4")):
 			api_key_info = {"key_name": "OPENAI_API_KEY", "prefix": "sk-"}
 		elif interp.INTERPRETER_MODEL.startswith("groq/") or "groq" in interp.INTERPRETER_MODEL:

--- a/scripts/smoke_all_models.py
+++ b/scripts/smoke_all_models.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Smoke-test matrix for every configs/*.json model.
+
+Offline (default): validate config schema + key routing + initialize_client with fake keys.
+Live: set SMOKE_LIVE=1 and provide real provider keys in .env / environment.
+
+Usage:
+  python scripts/smoke_all_models.py
+  SMOKE_LIVE=1 python scripts/smoke_all_models.py
+  SMOKE_LIVE=1 python scripts/smoke_all_models.py --only openrouter,groq,local
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import traceback
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+os.chdir(ROOT)
+load_dotenv(ROOT / ".env", override=True)
+
+CONFIG_DIR = ROOT / "configs"
+
+
+def expected_key(model: str, provider: str = "") -> str | None:
+	model = (model or "").strip()
+	provider = (provider or "").strip().lower()
+	if "local" in model or "ollama" in model or provider in ("ollama", "local", "lmstudio"):
+		return None
+	if provider == "nvidia":
+		return "NVIDIA_API_KEY"
+	if provider in ("z-ai", "zai"):
+		return "Z_AI_API_KEY"
+	if provider in ("browser-use", "browser_use"):
+		return "BROWSER_USE_API_KEY"
+	if provider == "openrouter":
+		return "OPENROUTER_API_KEY"
+	if model.startswith("nvidia/"):
+		return "NVIDIA_API_KEY"
+	if model.startswith(("glm-", "z-ai/", "zai/")):
+		return "Z_AI_API_KEY"
+	if model.startswith(("bu-", "browser-use/")):
+		return "BROWSER_USE_API_KEY"
+	if model.startswith(("gpt", "o1", "o3", "o4")):
+		return "OPENAI_API_KEY"
+	if model.startswith("groq/") or "groq" in model:
+		return "GROQ_API_KEY"
+	if "claude" in model:
+		return "ANTHROPIC_API_KEY"
+	if "gemini" in model:
+		return "GEMINI_API_KEY"
+	if "deepseek" in model:
+		return "DEEPSEEK_API_KEY"
+	return "HUGGINGFACE_API_KEY"
+
+
+def key_looks_real(key_name: str | None) -> bool:
+	if key_name is None:
+		return True
+	value = (os.getenv(key_name) or "").strip()
+	if not value or len(value) < 16:
+		return False
+	low = value.lower()
+	if any(tok in low for tok in ("your_", "changeme", "placeholder", "example", "xxx", "dummy")):
+		return False
+	if key_name == "OPENAI_API_KEY" and "1234567890" in value:
+		return False
+	return True
+
+
+def family_filter(only: set[str] | None, key: str | None, provider: str) -> bool:
+	if not only:
+		return True
+	tokens = set()
+	if key:
+		tokens.add(key.replace("_API_KEY", "").lower().replace("_", "-"))
+		tokens.add(key.lower())
+	tokens.add((provider or "unknown").lower())
+	if key is None:
+		tokens.add("local")
+	return bool(tokens & only)
+
+
+def offline_row(label: str, config: dict) -> tuple[str, str]:
+	from unittest.mock import MagicMock, patch
+	from libs.interpreter_lib import Interpreter
+	from libs.llm_dispatcher import build_completion_kwargs
+
+	model = str(config["model"])
+	provider = str(config.get("provider", ""))
+	key = expected_key(model, provider)
+	fake = {
+		"OPENAI_API_KEY": "sk-unittest-openai-key-1234567890",
+		"ANTHROPIC_API_KEY": "sk-ant-unittest-anthropic-key",
+		"GEMINI_API_KEY": "gemini-unittest-key-123456",
+		"GROQ_API_KEY": "gsk_unittest_groq_key_123456",
+		"HUGGINGFACE_API_KEY": "hf_unittest_huggingface_key",
+		"NVIDIA_API_KEY": "nvapi-unittest-nvidia-key",
+		"DEEPSEEK_API_KEY": "deepseek-unittest-key-123",
+		"Z_AI_API_KEY": "zai-unittest-key-12345",
+		"OPENROUTER_API_KEY": "sk-or-v1-unittest-openrouter",
+		"BROWSER_USE_API_KEY": "bu_unittest_browser_use_key",
+	}
+	env = {key: fake[key]} if key in fake else {}
+	mock_um = MagicMock()
+	mock_um.get_default_model_name.return_value = "gpt-4o"
+	mock_um.read_config_file.return_value = dict(config)
+	args = MagicMock(
+		model=label, mode="code", lang="python", save_code=False, exec=False,
+		display_code=False, history=False, unsafe=False, sandbox=True, file=None,
+		tui=False, cli=True, agent=False, agentic=False,
+	)
+	with patch("libs.interpreter_lib.UtilityManager", return_value=mock_um), \
+		patch("libs.interpreter_lib.load_dotenv"), \
+		patch.dict(os.environ, env, clear=True):
+		interp = Interpreter(args)
+		assert interp.INTERPRETER_MODEL == model
+		build_completion_kwargs(
+			model=model,
+			messages=[{"role": "user", "content": "ping"}],
+			temperature=0.1,
+			max_tokens=32,
+			config_provider=provider,
+			api_base=str(config.get("api_base", "None")),
+		)
+	return "PASS", f"offline ok → key={key or 'LOCAL'}"
+
+
+def live_row(label: str, config: dict) -> tuple[str, str]:
+	import litellm
+	from libs.llm_dispatcher import build_completion_kwargs
+
+	litellm.set_verbose = False
+	model = str(config["model"])
+	provider = str(config.get("provider", ""))
+	key = expected_key(model, provider)
+	if key is None:
+		return "SKIP", "local endpoint — use mock smoke"
+	if not key_looks_real(key):
+		return "SKIP", f"missing/invalid {key}"
+	if any(x in model.lower() for x in ("o1", "o3", "reasoner", "opus-4", "gpt-5.4")) and "mini" not in model.lower() and "nano" not in model.lower():
+		# Still allow free openrouter; skip expensive cloud models by default
+		if provider != "openrouter" or ":free" not in model:
+			if "free" not in label and "mini" not in label and "flash" not in label and "nano" not in label:
+				return "SKIP", "expensive/reasoning model skipped in default live matrix"
+
+	kwargs = build_completion_kwargs(
+		model=model,
+		messages=[
+			{"role": "system", "content": "Reply with exactly PONG."},
+			{"role": "user", "content": "ping"},
+		],
+		temperature=0,
+		max_tokens=16,
+		config_provider=provider,
+		api_base=str(config.get("api_base", "None")),
+	)
+	response = litellm.completion(model=model, **kwargs)
+	text = ""
+	try:
+		text = response.choices[0].message.content or ""
+	except Exception:
+		text = str(response)
+	if not str(text).strip():
+		return "FAIL", "empty response"
+	return "PASS", f"live ok ({len(str(text))} chars)"
+
+
+def main() -> int:
+	parser = argparse.ArgumentParser(description="Smoke matrix for all model configs")
+	parser.add_argument("--only", default="", help="Comma filter: openai,anthropic,gemini,groq,openrouter,local,...")
+	parser.add_argument("--live", action="store_true", help="Hit live APIs (or set SMOKE_LIVE=1)")
+	args = parser.parse_args()
+	live = args.live or os.getenv("SMOKE_LIVE") == "1"
+	only = {x.strip().lower() for x in args.only.split(",") if x.strip()} or None
+
+	rows = []
+	for path in sorted(CONFIG_DIR.glob("*.json")):
+		config = json.loads(path.read_text())
+		key = expected_key(str(config.get("model", "")), str(config.get("provider", "")))
+		provider = str(config.get("provider", "") or "unknown")
+		if not family_filter(only, key, provider):
+			continue
+		label = path.stem
+		try:
+			status, detail = live_row(label, config) if live else offline_row(label, config)
+		except Exception as exc:
+			status, detail = "FAIL", f"{type(exc).__name__}: {exc}"
+			if os.getenv("SMOKE_VERBOSE"):
+				traceback.print_exc()
+		rows.append((status, label, key or "LOCAL", detail))
+		print(f"[{status:4}] {label:40} {detail}")
+
+	counts = {k: sum(1 for r in rows if r[0] == k) for k in ("PASS", "SKIP", "FAIL")}
+	print("\n=== SUMMARY ===")
+	print(f"PASS={counts['PASS']} SKIP={counts['SKIP']} FAIL={counts['FAIL']} TOTAL={len(rows)}")
+	print(f"mode={'LIVE' if live else 'OFFLINE'}")
+	# Write machine-readable report
+	out = ROOT / "logs" / "smoke_all_models.json"
+	out.parent.mkdir(parents=True, exist_ok=True)
+	out.write_text(json.dumps([
+		{"status": s, "label": l, "key": k, "detail": d} for s, l, k, d in rows
+	], indent=2))
+	print(f"report: {out}")
+	return 1 if counts["FAIL"] else 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/tests/smoke/test_live_model_smoke.py
+++ b/tests/smoke/test_live_model_smoke.py
@@ -1,0 +1,164 @@
+"""Live smoke tests against real provider APIs (skipped when keys are absent).
+
+Run:
+  python -m unittest discover -s tests/smoke -v
+  SMOKE_LIVE=1 python -m unittest discover -s tests/smoke -v
+
+Or the matrix CLI:
+  python scripts/smoke_all_models.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv(dotenv_path=Path(".env"), override=True)
+
+CONFIG_DIR = Path("configs")
+
+
+def _expected_key_for_model(model: str, provider: str = "") -> str | None:
+	model = (model or "").strip()
+	provider = (provider or "").strip().lower()
+	if "local" in model or "ollama" in model or provider in ("ollama", "local", "lmstudio"):
+		return None
+	if provider == "nvidia":
+		return "NVIDIA_API_KEY"
+	if provider in ("z-ai", "zai"):
+		return "Z_AI_API_KEY"
+	if provider in ("browser-use", "browser_use"):
+		return "BROWSER_USE_API_KEY"
+	if provider == "openrouter":
+		return "OPENROUTER_API_KEY"
+	if model.startswith("nvidia/"):
+		return "NVIDIA_API_KEY"
+	if model.startswith(("glm-", "z-ai/", "zai/")):
+		return "Z_AI_API_KEY"
+	if model.startswith(("bu-", "browser-use/")):
+		return "BROWSER_USE_API_KEY"
+	if model.startswith(("gpt", "o1", "o3", "o4")):
+		return "OPENAI_API_KEY"
+	if model.startswith("groq/") or "groq" in model:
+		return "GROQ_API_KEY"
+	if "claude" in model:
+		return "ANTHROPIC_API_KEY"
+	if "gemini" in model:
+		return "GEMINI_API_KEY"
+	if "deepseek" in model:
+		return "DEEPSEEK_API_KEY"
+	return "HUGGINGFACE_API_KEY"
+
+
+def _key_looks_real(key_name: str | None) -> bool:
+	if key_name is None:
+		return True  # local
+	value = (os.getenv(key_name) or "").strip()
+	if not value or len(value) < 16:
+		return False
+	low = value.lower()
+	if any(tok in low for tok in ("your_", "changeme", "placeholder", "example", "xxx", "dummy")):
+		return False
+	if key_name == "OPENAI_API_KEY" and ("1234567890" in value or value == "sk-1234567890"):
+		return False
+	prefixes = {
+		"OPENAI_API_KEY": "sk-",
+		"ANTHROPIC_API_KEY": "sk-ant-",
+		"GROQ_API_KEY": "gsk",
+		"HUGGINGFACE_API_KEY": "hf_",
+		"NVIDIA_API_KEY": "nvapi-",
+		"OPENROUTER_API_KEY": "sk-or-v1-",
+		"BROWSER_USE_API_KEY": "bu_",
+	}
+	prefix = prefixes.get(key_name)
+	if prefix and not value.startswith(prefix):
+		return False
+	return True
+
+
+def _one_config_per_key_family():
+	"""Pick one representative config label per required API key (plus local)."""
+	picked = {}
+	for path in sorted(CONFIG_DIR.glob("*.json")):
+		data = json.loads(path.read_text())
+		key = _expected_key_for_model(str(data.get("model", "")), str(data.get("provider", "")))
+		family = key or "LOCAL"
+		# Prefer free/openrouter-free and gpt-4o-mini / flash models when available
+		prefer = (
+			"openrouter-free" in path.stem
+			or "flash" in path.stem
+			or "mini" in path.stem
+			or path.stem in ("local-model", "gpt-4o-mini", "groq-llama-3.1-8b", "deepseek-chat", "z-ai-glm-5")
+		)
+		if family not in picked or prefer:
+			picked[family] = (path.stem, data)
+	return picked
+
+
+@unittest.skipUnless(os.getenv("SMOKE_LIVE") == "1", "Set SMOKE_LIVE=1 to hit live provider APIs")
+class TestLiveModelSmoke(unittest.TestCase):
+	def test_live_completion_per_key_family(self):
+		import litellm
+		from libs.llm_dispatcher import build_completion_kwargs
+
+		litellm.set_verbose = False
+		families = _one_config_per_key_family()
+		self.assertTrue(families)
+
+		failures = []
+		skipped = []
+		passed = []
+
+		for family, (label, config) in sorted(families.items()):
+			key = _expected_key_for_model(str(config.get("model", "")), str(config.get("provider", "")))
+			if family == "LOCAL":
+				skipped.append(f"{label}: local endpoint (covered by mock smoke)")
+				continue
+			if not _key_looks_real(key):
+				skipped.append(f"{label}: missing/invalid {key}")
+				continue
+			model = str(config["model"])
+			provider = str(config.get("provider", ""))
+			api_base = str(config.get("api_base", "None"))
+			try:
+				kwargs = build_completion_kwargs(
+					model=model,
+					messages=[
+						{"role": "system", "content": "Reply with exactly the word PONG and nothing else."},
+						{"role": "user", "content": "ping"},
+					],
+					temperature=0,
+					max_tokens=16,
+					config_provider=provider,
+					api_base=api_base,
+				)
+				# Avoid huge spend / slow reasoning models in smoke
+				if any(x in model.lower() for x in ("o1", "o3", "o4", "reasoner", "opus")):
+					skipped.append(f"{label}: skipped expensive/reasoning model in family smoke")
+					continue
+				response = litellm.completion(model=model, **kwargs)
+				text = ""
+				try:
+					text = response.choices[0].message.content or ""
+				except Exception:
+					text = str(response)
+				if not str(text).strip():
+					failures.append(f"{label}: empty response")
+				else:
+					passed.append(f"{label}: ok ({len(str(text))} chars)")
+			except Exception as exc:
+				failures.append(f"{label}: {type(exc).__name__}: {exc}")
+
+		report = "\nPASSED:\n  " + "\n  ".join(passed or ["(none)"])
+		report += "\nSKIPPED:\n  " + "\n  ".join(skipped or ["(none)"])
+		report += "\nFAILED:\n  " + "\n  ".join(failures or ["(none)"])
+		print(report)
+		self.assertFalse(failures, report)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/smoke/test_local_model_smoke.py
+++ b/tests/smoke/test_local_model_smoke.py
@@ -1,0 +1,107 @@
+"""Local-model smoke: OpenAI-compatible mock on :11434 + interpreter CLI path."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class _Handler(BaseHTTPRequestHandler):
+	def log_message(self, format, *args):  # noqa: A003
+		return
+
+	def do_POST(self):  # noqa: N802
+		length = int(self.headers.get("Content-Length", "0"))
+		_ = self.rfile.read(length)
+		body = {
+			"id": "chatcmpl-smoke",
+			"object": "chat.completion",
+			"choices": [{
+				"index": 0,
+				"message": {
+					"role": "assistant",
+					"content": "```python\nprint('smoke-ok')\n```",
+				},
+				"finish_reason": "stop",
+			}],
+		}
+		payload = json.dumps(body).encode()
+		self.send_response(200)
+		self.send_header("Content-Type", "application/json")
+		self.send_header("Content-Length", str(len(payload)))
+		self.end_headers()
+		self.wfile.write(payload)
+
+
+def _port_free(port: int) -> bool:
+	with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+		sock.settimeout(0.2)
+		return sock.connect_ex(("127.0.0.1", port)) != 0
+
+
+class TestLocalModelSmoke(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		cls.port = 11434
+		cls._owned_server = False
+		if _port_free(cls.port):
+			cls.server = HTTPServer(("127.0.0.1", cls.port), _Handler)
+			cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+			cls.thread.start()
+			cls._owned_server = True
+			time.sleep(0.2)
+
+	@classmethod
+	def tearDownClass(cls):
+		if getattr(cls, "_owned_server", False):
+			cls.server.shutdown()
+			cls.server.server_close()
+
+	def test_local_model_generate_content_via_litellm_path(self):
+		from argparse import Namespace
+		from libs.interpreter_lib import Interpreter
+
+		args = Namespace(
+			model="local-model", mode="code", lang="python", save_code=False, exec=False,
+			display_code=False, history=False, unsafe=False, sandbox=True, file=None,
+			tui=False, cli=True, agent=False, agentic=False,
+		)
+		env = {
+			"OPENAI_API_KEY": "sk-local-smoke",
+			"HUGGINGFACE_API_KEY": "hf_local_smoke_placeholder_xx",
+		}
+		with patch.dict(os.environ, env, clear=False):
+			interp = Interpreter(args)
+			text = interp.generate_content(
+				"print smoke-ok",
+				chat_history=[],
+				config_values=interp.config_values,
+			)
+		self.assertIn("```", text)
+		self.assertTrue("python" in text.lower() or "print" in text.lower(), text[:200])
+
+	def test_cli_help_lists_local_model_label(self):
+		result = subprocess.run(
+			[sys.executable, str(ROOT / "interpreter.py"), "--help"],
+			cwd=ROOT,
+			capture_output=True,
+			text=True,
+			timeout=60,
+		)
+		self.assertEqual(result.returncode, 0)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/test_all_model_configs.py
+++ b/tests/test_all_model_configs.py
@@ -1,0 +1,198 @@
+"""Offline unit tests for every configs/*.json model entry.
+
+Covers schema validity, provider/key routing, and initialize_client validation
+without calling live provider APIs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from libs.interpreter_lib import Interpreter
+from libs.llm_dispatcher import _detect_provider, build_completion_kwargs
+
+
+CONFIG_DIR = Path("configs")
+REQUIRED_FIELDS = ("temperature", "max_tokens", "start_sep", "end_sep", "model")
+
+
+def _all_configs():
+	paths = sorted(CONFIG_DIR.glob("*.json"))
+	assert paths, "No configs/*.json found"
+	return paths
+
+
+def _expected_key_for_model(model: str, provider: str = "") -> str | None:
+	"""Mirror ModelRouter.initialize_client key selection.
+
+	Config ``provider`` wins over model-id heuristics so OpenRouter models that
+	still carry an ``nvidia/...`` id require OPENROUTER_API_KEY, not NVIDIA.
+	"""
+	model = (model or "").strip()
+	provider = (provider or "").strip().lower()
+	if "local" in model or "ollama" in model or provider in ("ollama", "local", "lmstudio"):
+		return None
+	if provider == "nvidia":
+		return "NVIDIA_API_KEY"
+	if provider in ("z-ai", "zai"):
+		return "Z_AI_API_KEY"
+	if provider in ("browser-use", "browser_use"):
+		return "BROWSER_USE_API_KEY"
+	if provider == "openrouter":
+		return "OPENROUTER_API_KEY"
+	if model.startswith("nvidia/"):
+		return "NVIDIA_API_KEY"
+	if model.startswith(("glm-", "z-ai/", "zai/")):
+		return "Z_AI_API_KEY"
+	if model.startswith(("bu-", "browser-use/")):
+		return "BROWSER_USE_API_KEY"
+	if model.startswith(("gpt", "o1", "o3", "o4")):
+		return "OPENAI_API_KEY"
+	if model.startswith("groq/") or "groq" in model:
+		return "GROQ_API_KEY"
+	if "claude" in model:
+		return "ANTHROPIC_API_KEY"
+	if "gemini" in model:
+		return "GEMINI_API_KEY"
+	if "deepseek" in model:
+		return "DEEPSEEK_API_KEY"
+	return "HUGGINGFACE_API_KEY"
+
+
+def _valid_env_for_key(key_name: str) -> dict:
+	samples = {
+		"OPENAI_API_KEY": "sk-unittest-openai-key-1234567890",
+		"ANTHROPIC_API_KEY": "sk-ant-unittest-anthropic-key",
+		"GEMINI_API_KEY": "gemini-unittest-key-123456",
+		"GROQ_API_KEY": "gsk_unittest_groq_key_123456",
+		"HUGGINGFACE_API_KEY": "hf_unittest_huggingface_key",
+		"NVIDIA_API_KEY": "nvapi-unittest-nvidia-key",
+		"DEEPSEEK_API_KEY": "deepseek-unittest-key-123",
+		"Z_AI_API_KEY": "zai-unittest-key-12345",
+		"OPENROUTER_API_KEY": "sk-or-v1-unittest-openrouter",
+		"BROWSER_USE_API_KEY": "bu_unittest_browser_use_key",
+	}
+	return {key_name: samples[key_name]} if key_name in samples else {}
+
+
+class TestAllModelConfigsSchema(unittest.TestCase):
+	def test_every_config_has_required_fields(self):
+		for path in _all_configs():
+			with self.subTest(config=path.name):
+				data = json.loads(path.read_text())
+				for field in REQUIRED_FIELDS:
+					self.assertIn(field, data, f"{path.name} missing {field}")
+				self.assertIsInstance(data["temperature"], (int, float))
+				self.assertIsInstance(data["max_tokens"], int)
+				self.assertTrue(str(data["model"]).strip())
+
+	def test_config_count_matches_directory(self):
+		self.assertGreaterEqual(len(_all_configs()), 50)
+
+
+class TestAllModelKeyRouting(unittest.TestCase):
+	def test_key_routing_table_for_every_config(self):
+		for path in _all_configs():
+			with self.subTest(config=path.name):
+				data = json.loads(path.read_text())
+				model = str(data.get("model", ""))
+				provider = str(data.get("provider", ""))
+				key = _expected_key_for_model(model, provider)
+				detected = _detect_provider(model, provider, str(data.get("api_base", "None")))
+				if key is None:
+					self.assertIn(detected, ("local", "huggingface"), msg=f"{path.name} local expected")
+				else:
+					self.assertTrue(key.endswith("_API_KEY") or key.endswith("_KEY"))
+
+
+class TestAllModelInitializeClient(unittest.TestCase):
+	"""initialize_client accepts a valid key for every non-local config label."""
+
+	def setUp(self):
+		self.mock_um = MagicMock()
+		self.mock_um.get_default_model_name.return_value = "gpt-4o"
+		self.p_um = patch("libs.interpreter_lib.UtilityManager", return_value=self.mock_um)
+		self.p_dotenv = patch("libs.interpreter_lib.load_dotenv")
+		self.p_um.start()
+		self.p_dotenv.start()
+
+	def tearDown(self):
+		patch.stopall()
+
+	def _make(self, label: str, config: dict) -> Interpreter:
+		args = MagicMock()
+		args.model = label
+		args.mode = "code"
+		args.lang = "python"
+		args.save_code = False
+		args.exec = False
+		args.display_code = False
+		args.history = False
+		args.unsafe = False
+		args.sandbox = True
+		args.file = None
+		args.tui = False
+		args.cli = True
+		args.agent = False
+		args.agentic = False
+		self.mock_um.read_config_file.return_value = dict(config)
+		return Interpreter(args)
+
+	def test_initialize_client_with_valid_key_for_each_config(self):
+		for path in _all_configs():
+			with self.subTest(config=path.name):
+				label = path.stem
+				config = json.loads(path.read_text())
+				model = str(config.get("model", ""))
+				provider = str(config.get("provider", ""))
+				key = _expected_key_for_model(model, provider)
+				env = _valid_env_for_key(key) if key else {}
+				with patch.dict(os.environ, env, clear=True):
+					interp = self._make(label, config)
+					self.assertEqual(interp.INTERPRETER_MODEL, model)
+
+	def test_build_completion_kwargs_for_each_config(self):
+		for path in _all_configs():
+			with self.subTest(config=path.name):
+				config = json.loads(path.read_text())
+				model = str(config["model"])
+				provider = str(config.get("provider", ""))
+				api_base = str(config.get("api_base", "None"))
+				key = _expected_key_for_model(model, provider)
+				env = _valid_env_for_key(key) if key else {"OPENAI_API_KEY": "sk-local"}
+				with patch.dict(os.environ, env, clear=False):
+					kwargs = build_completion_kwargs(
+						model=model,
+						messages=[{"role": "user", "content": "ping"}],
+						temperature=float(config.get("temperature", 0.1)),
+						max_tokens=int(config.get("max_tokens", 64)),
+						config_provider=provider,
+						api_base=api_base,
+					)
+					self.assertIn("messages", kwargs)
+
+
+class TestModelSmokeOfflineMatrix(unittest.TestCase):
+	"""Documented matrix: every config maps to exactly one auth strategy."""
+
+	def test_unique_config_labels(self):
+		labels = [p.stem for p in _all_configs()]
+		self.assertEqual(len(labels), len(set(labels)))
+
+	def test_provider_families_covered(self):
+		families = set()
+		for path in _all_configs():
+			data = json.loads(path.read_text())
+			key = _expected_key_for_model(str(data.get("model", "")), str(data.get("provider", "")))
+			families.add(key or "LOCAL")
+		# Expect major families present in the catalog
+		for needed in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GROQ_API_KEY", "LOCAL"):
+			self.assertIn(needed, families)
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a full **offline unit/smoke matrix for all 68 `configs/*.json` models**, a gated **live provider smoke harness**, and fixes ModelRouter auth routing bugs found by the matrix.

### Fixes
- `provider: local|ollama|lmstudio` skips cloud API key checks (local-model no longer requires HuggingFace)
- Config `provider` wins over model-id heuristics (OpenRouter configs with `nvidia/...` ids correctly require `OPENROUTER_API_KEY`)

### Tests / tooling
- `tests/test_all_model_configs.py` — schema + key routing + `initialize_client` for every config
- `scripts/smoke_all_models.py` — offline/live matrix CLI (`SMOKE_LIVE=1` for live)
- `tests/smoke/test_local_model_smoke.py` — local OpenAI-compatible mock smoke
- `tests/smoke/test_live_model_smoke.py` — live family smoke (skipped unless `SMOKE_LIVE=1`)

### Results (this branch)
| Check | Result |
|---|---|
| Offline matrix (`scripts/smoke_all_models.py`) | **68/68 PASS** |
| Local mock smoke | PASS |
| Full unittest | **341 OK** (1 skipped gated live) |
| Live cloud smoke | blocked — no real provider API keys in the VM |

## Test plan
- [x] Offline matrix 68/68
- [x] Full unittest
- [ ] CI backend green
- [ ] Re-run `SMOKE_LIVE=1 python scripts/smoke_all_models.py` after provider secrets are added

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51849831-423f-474c-b018-5466c392cbb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51849831-423f-474c-b018-5466c392cbb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

