### PR TITLE
🎨 Palette: Add Ctrl-C cancellation to TUI prompts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-07-08 - Displaying choices in Rich prompts without breaking case-insensitivity
 **Learning:** When using `rich.prompt.Prompt.ask()`, providing the `choices` argument enforces strict, case-sensitive input matching which overrides custom case-insensitivity logic. Additionally, to manually format the choices into the prompt string, brackets must be escaped as `\\[` to prevent `rich` from incorrectly parsing them as markup and to avoid Python syntax warnings.
 **Action:** When we need to show choices but still allow custom validation (like case-insensitivity), format the choices directly into the prompt string and escape the brackets.
+## 2025-02-12 - Handling KeyboardInterrupt gracefully in Terminal UIs
+**Learning:** In terminal UIs reading raw standard input byte-by-byte, users intuitively expect Ctrl-C (`\x03`) to exit/cancel. We cannot advertise the 'Esc' (`\x1b`) key for cancelling, as it requires a blocking read for potential subsequent ANSI sequence characters, causing the app to hang. Instead, directly capturing the `\x03` byte and raising `KeyboardInterrupt` explicitly offers better UX and avoids keyboard traps.
+**Action:** Always capture standard interrupt bytes like `\x03` and explicitly map them to interrupts in raw read modes, and explicitly hint users with 'Ctrl-C to cancel'.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -27,6 +27,10 @@ class TerminalUI:
                 return 'enter'
             if key == '\x1b':
                 return 'escape'
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
+            if key == '\x04':
+                raise EOFError('EOF')
             return key
 
         import termios
@@ -43,6 +47,10 @@ class TerminalUI:
                 return mapping.get(next_chars, 'escape')
             if key in ('\r', '\n'):
                 return 'enter'
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
+            if key == '\x04':
+                raise EOFError('EOF')
             return key
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
@@ -68,6 +76,7 @@ class TerminalUI:
             table.add_row(marker, label, style=style)
 
         footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer += ' | Ctrl-C to cancel'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)


### PR DESCRIPTION
- 💡 What: Added direct handling for Ctrl-C (`\x03`) and Ctrl-D (`\x04`) in raw stdin read mode to throw KeyboardInterrupt and EOFError, and added a visual "Ctrl-C to cancel" hint.
- 🎯 Why: Previously, users couldn't gracefully cancel out of interactive TUI prompts without hanging the application or closing the terminal.
- 📸 Before/After: Visual hint added to footer panel.
- ♿ Accessibility: Improved keyboard accessibility and provided clear, visible instructions to avoid terminal keyboard traps.

---
*PR created automatically by Jules for task [4118026040409385075](https://jules.google.com/task/4118026040409385075) started by @haseeb-heaven*