### PR TITLE
🎨 Palette: Add explicit Ctrl-C cancellation to TUI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-07-08 - Displaying choices in Rich prompts without breaking case-insensitivity
 **Learning:** When using `rich.prompt.Prompt.ask()`, providing the `choices` argument enforces strict, case-sensitive input matching which overrides custom case-insensitivity logic. Additionally, to manually format the choices into the prompt string, brackets must be escaped as `\\[` to prevent `rich` from incorrectly parsing them as markup and to avoid Python syntax warnings.
 **Action:** When we need to show choices but still allow custom validation (like case-insensitivity), format the choices directly into the prompt string and escape the brackets.
+## 2026-07-13 - TUI Cancellation Keyboard Traps
+**Learning:** In terminal UIs using raw mode input, standard cancellation via the Escape key (`\x1b`) can cause the application to hang when followed by blocking multi-character reads for ANSI sequences. Standard interrupt bytes like `\x03` (Ctrl-C) are safer for explicit cancellation.
+**Action:** Always provide explicit keyboard hints for cancellation (e.g., 'Ctrl-C to cancel') and explicitly raise `KeyboardInterrupt` for `\x03` in raw mode key readers to prevent application hangs.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -27,6 +27,8 @@ class TerminalUI:
                 return 'enter'
             if key == '\x1b':
                 return 'escape'
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
             return key
 
         import termios
@@ -43,6 +45,8 @@ class TerminalUI:
                 return mapping.get(next_chars, 'escape')
             if key in ('\r', '\n'):
                 return 'enter'
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
             return key
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
@@ -68,6 +72,7 @@ class TerminalUI:
             table.add_row(marker, label, style=style)
 
         footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer += ' (Ctrl-C to cancel)'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)


### PR DESCRIPTION
💡 **What:** Added explicit handling for the `\x03` (Ctrl-C) character to raise a `KeyboardInterrupt` in the terminal UI's raw mode key readers, and updated the TUI selector footer to visibly state `(Ctrl-C to cancel)`.
🎯 **Why:** To prevent keyboard traps where standard escape keys (`\x1b`) can cause the application to hang when followed by multi-character blocking reads, providing a clear and reliable way out for users.
📸 **Before/After:** Before, the selector hinted `Use Up/Down arrows and Enter to select.`. Now it hints `Use Up/Down arrows and Enter to select. (Ctrl-C to cancel)`.
♿ **Accessibility:** Prevents users from getting stuck in a keyboard trap by establishing a reliable and visible exit strategy.

---
*PR created automatically by Jules for task [6104945904503465619](https://jules.google.com/task/6104945904503465619) started by @haseeb-heaven*