### PR TITLE
🎨 Palette: Add Ctrl-C cancellation to TUI prompts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-07-08 - Displaying choices in Rich prompts without breaking case-insensitivity
 **Learning:** When using `rich.prompt.Prompt.ask()`, providing the `choices` argument enforces strict, case-sensitive input matching which overrides custom case-insensitivity logic. Additionally, to manually format the choices into the prompt string, brackets must be escaped as `\\[` to prevent `rich` from incorrectly parsing them as markup and to avoid Python syntax warnings.
 **Action:** When we need to show choices but still allow custom validation (like case-insensitivity), format the choices directly into the prompt string and escape the brackets.
+
+## 2024-07-14 - Preventing Keyboard Traps in Raw Terminal Modes
+**Learning:** In terminal UI environments, avoiding keyboard traps requires explicitly raising `KeyboardInterrupt` when standard interrupt bytes (`\x03`) are read in raw mode. Advertising 'Esc' (`\x1b`) as a cancel action causes issues as reading it in raw mode followed by a blocking `sys.stdin.read(2)` for ANSI sequences hangs the application.
+**Action:** Always handle `\x03` to raise `KeyboardInterrupt` and provide explicit shortcut hints like 'Ctrl-C to cancel'. Do not advertise 'Esc' for cancellation.

--- a/libs/terminal_ui.py
+++ b/libs/terminal_ui.py
@@ -25,6 +25,8 @@ class TerminalUI:
                 return mapping.get(extended, extended)
             if key == '\r':
                 return 'enter'
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
             if key == '\x1b':
                 return 'escape'
             return key
@@ -37,6 +39,8 @@ class TerminalUI:
         try:
             tty.setraw(fd)
             key = sys.stdin.read(1)
+            if key == '\x03':
+                raise KeyboardInterrupt('Selection cancelled by user.')
             if key == '\x1b':
                 next_chars = sys.stdin.read(2)
                 mapping = {'[A': 'up', '[B': 'down', '[D': 'left', '[C': 'right'}
@@ -67,7 +71,7 @@ class TerminalUI:
             style = 'bold green' if index == selected_index else ''
             table.add_row(marker, label, style=style)
 
-        footer = help_text or 'Use Up/Down arrows and Enter to select.'
+        footer = help_text or 'Use Up/Down arrows and Enter to select. Ctrl-C to cancel.'
         self.console.print(Panel.fit(footer, title='Interpreter TUI', border_style='green'))
         self.console.print(f"[bold cyan]{title}[/bold cyan]")
         self.console.print(table)
@@ -110,7 +114,7 @@ class TerminalUI:
 
     def _select_boolean(self, title, default=False):
         default_choice = 'yes' if default else 'no'
-        choice = self._select_option(title, ['yes', 'no'], default_choice, 'Use Up/Down arrows and Enter to choose.')
+        choice = self._select_option(title, ['yes', 'no'], default_choice, 'Use Up/Down arrows and Enter to choose. Ctrl-C to cancel.')
         return choice == 'yes'
 
     def select_mode(self, default_mode='code'):
@@ -121,7 +125,7 @@ class TerminalUI:
         default_model = default_model or self.utility_manager.get_default_model_name()
         if default_model not in models:
             default_model = models[0]
-        return self._select_option('Model', models, default_model, 'Use Up/Down arrows, Enter, or type the first letter to jump.')
+        return self._select_option('Model', models, default_model, 'Use Up/Down arrows, Enter, or type the first letter to jump. Ctrl-C to cancel.')
 
     def select_language(self, default_lang='python'):
         return self._select_option('Language', ['python', 'javascript'], default_lang)


### PR DESCRIPTION
💡 What: Modified `libs/terminal_ui.py` to correctly capture `\x03` (Ctrl-C) when reading input in raw terminal modes (both Windows and POSIX) and raise a `KeyboardInterrupt`. Also updated all selection prompts to explicitly indicate "Ctrl-C to cancel."

🎯 Why: In raw terminal mode, the standard `Ctrl-C` interrupt byte (`\x03`) is captured as a raw character rather than immediately generating a Python exception. Previously, this meant `Ctrl-C` would be ignored, trapping the user inside the TUI selection menus with no obvious way to escape. Additionally, trying to use the Escape key in raw mode would hang the application if it anticipated a longer ANSI sequence.

📸 Before/After: Before, pressing `Ctrl-C` in a selection menu did nothing. Now, pressing `Ctrl-C` cancels the selection menu and exits the program cleanly. Help text at the bottom of the screen has been updated from `Use Up/Down arrows and Enter to select.` to `Use Up/Down arrows and Enter to select. Ctrl-C to cancel.`.

♿ Accessibility: Prevents a severe "keyboard trap", a critical accessibility requirement (WCAG 2.1.2 No Keyboard Trap). Ensures users using screen readers and keyboard navigation can always cleanly exit an interaction.

---
*PR created automatically by Jules for task [8377261030445174090](https://jules.google.com/task/8377261030445174090) started by @haseeb-heaven*