### PR TITLE
test(live): drive every CLI mode end-to-end like a real user, no mocks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,10 @@ external LLM providers over HTTP; there is nothing long-running to "start" besid
     `python scripts/smoke_all_models.py`
   - Live provider smoke (needs real keys): `SMOKE_LIVE=1 python scripts/smoke_all_models.py`
   - Local mock smoke: `python -m unittest tests.smoke.test_local_model_smoke`
+  - Real-user, real-subprocess coverage for every mode (`--cli`, `--agentic`, `--gemini-style`,
+    `--yolo`, `--agent`, `/settings` wizard, `--search`) against a protocol-aware local stub
+    (`scripts/live_stub_llm_server.py`) — no keys needed, no mocked internals, drives the actual
+    binary end to end: `python -m unittest discover -s tests/live -p 'test_live_human_scenarios.py' -v`
 - TestSprite backend suite (CLI only, no frontend):
   `python -m unittest discover -s testsprite_tests -p 'TC*.py' -v`
 - Some passing tests intentionally print argparse `usage:`/error text and `SyntaxWarning` lines to the

--- a/scripts/live_stub_llm_server.py
+++ b/scripts/live_stub_llm_server.py
@@ -38,12 +38,30 @@ from typing import Any
 
 
 def _port_free(port: int, host: str = "127.0.0.1") -> bool:
+    """Check whether a TCP port is available on the specified host.
+    
+    Parameters:
+    	port (int): The TCP port to check.
+    	host (str): The host address to check.
+    
+    Returns:
+    	bool: `True` if the port is available, `False` if a connection succeeds.
+    """
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.settimeout(0.2)
         return sock.connect_ex((host, port)) != 0
 
 
 def _system_content(messages: list[dict]) -> str:
+    """
+    Extract the content of the first system message.
+    
+    Parameters:
+    	messages (list[dict]): Chat messages to inspect.
+    
+    Returns:
+    	str: The system message content, or an empty string when no string-valued system message exists.
+    """
     for msg in messages:
         if msg.get("role") == "system":
             content = msg.get("content")
@@ -52,6 +70,14 @@ def _system_content(messages: list[dict]) -> str:
 
 
 def _last_user_content(messages: list[dict]) -> str:
+    """Return the content of the last user message.
+    
+    Parameters:
+    	messages (list[dict]): Chat messages to search in reverse order.
+    
+    Returns:
+    	str: The message content if it is a string; otherwise, an empty string.
+    """
     for msg in reversed(messages):
         if msg.get("role") == "user":
             content = msg.get("content")
@@ -60,6 +86,16 @@ def _last_user_content(messages: list[dict]) -> str:
 
 
 def _chat_response(content: str, *, tool_calls: list[dict] | None = None) -> dict:
+    """
+    Builds an OpenAI-compatible chat completion response payload.
+    
+    Parameters:
+        content (str): Assistant message content.
+        tool_calls (list[dict] | None): Optional tool calls to include in the response.
+    
+    Returns:
+        dict: A chat completion payload containing the assistant message, completion status, and usage data.
+    """
     message: dict[str, Any] = {"role": "assistant", "content": content}
     if tool_calls:
         message["tool_calls"] = tool_calls
@@ -78,7 +114,15 @@ def _chat_response(content: str, *, tool_calls: list[dict] | None = None) -> dic
 
 
 def _react_step_response(user_content: str) -> str:
-    """Cycle a ReAct agent through code -> execute -> review -> finish."""
+    """
+    Generate the next protocol-formatted ReAct action for the task.
+    
+    Parameters:
+        user_content (str): Conversation content used to determine which action should be generated next.
+    
+    Returns:
+        str: A ReAct response containing a thought, action, and action input for the next step.
+    """
     if "Action: code" not in user_content:
         return (
             "Thought: I will write code to satisfy the task.\n"
@@ -105,7 +149,15 @@ def _react_step_response(user_content: str) -> str:
 
 
 def _autoloop_response(messages: list[dict]) -> tuple[str | None, list[dict] | None]:
-    """AutoLoop (--yolo/native tool_calls): call one tool, then finish."""
+    """
+    Generate the next AutoLoop response by completing a tool call or reporting completion.
+    
+    Parameters:
+    	messages (list[dict]): Chat messages used to detect prior tool execution and determine the requested task.
+    
+    Returns:
+    	tuple[str | None, list[dict] | None]: A completion message and no tool calls after a tool has run, or no message and one tool call for the requested web search or file-writing task.
+    """
     already_ran_tool = any(msg.get("role") == "tool" for msg in messages)
     if already_ran_tool:
         return "Done — tool call completed.", None
@@ -142,6 +194,15 @@ def _autoloop_response(messages: list[dict]) -> tuple[str | None, list[dict] | N
 
 
 def _route(body: dict) -> dict:
+    """
+    Routes a chat completion request to a protocol-specific stub response.
+    
+    Parameters:
+        body (dict): Request payload containing chat messages and optional tool definitions.
+    
+    Returns:
+        dict: An OpenAI-compatible chat completion response selected from the request contents.
+    """
     messages = body.get("messages") or []
     tools = body.get("tools")
     system = _system_content(messages)
@@ -184,6 +245,9 @@ class _Handler(BaseHTTPRequestHandler):
         return
 
     def do_POST(self):  # noqa: N802
+        """Handle a POST request by routing its JSON body and returning an OpenAI-compatible response.
+        
+        Malformed or empty request bodies are treated as empty objects."""
         length = int(self.headers.get("Content-Length", "0"))
         raw = self.rfile.read(length)
         try:
@@ -208,6 +272,13 @@ class StubLLMServer:
     """
 
     def __init__(self, host: str = "127.0.0.1", port: int = 11434):
+        """
+        Initialize the stub server configuration and runtime state.
+        
+        Parameters:
+            host (str): Host address on which to start the server.
+            port (int): TCP port on which to start the server.
+        """
         self.host = host
         self.port = port
         self.server: HTTPServer | None = None
@@ -215,6 +286,12 @@ class StubLLMServer:
         self.owned = False
 
     def __enter__(self) -> "StubLLMServer":
+        """
+        Start the stub server when the configured port is available.
+        
+        Returns:
+        	StubLLMServer: This server context manager.
+        """
         if _port_free(self.port, self.host):
             self.server = HTTPServer((self.host, self.port), _Handler)
             self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
@@ -223,6 +300,14 @@ class StubLLMServer:
         return self
 
     def __exit__(self, exc_type, exc, tb) -> None:
+        """
+        Stop the stub server when this context manager started it.
+        
+        Parameters:
+            exc_type: The exception type, if an exception occurred in the context.
+            exc: The exception instance, if an exception occurred in the context.
+            tb: The traceback, if an exception occurred in the context.
+        """
         if self.owned and self.server is not None:
             self.server.shutdown()
             self.server.server_close()

--- a/scripts/live_stub_llm_server.py
+++ b/scripts/live_stub_llm_server.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""A protocol-aware OpenAI-compatible stub LLM server for real end-to-end CLI runs.
+
+Unlike a single fixed-response stub, this one inspects the *system prompt* of
+each request to recognize which internal agent is calling (ReAct step /
+Coder / Reviewer / Debugger / IntentRouter / Planner / multi-agent Reviewer /
+AutoLoop tool-use) and replies with a protocol-correct message so that the
+real, unmodified pipeline (litellm dispatch -> HTTP -> response parse ->
+ReAct/AutoLoop/pipeline control flow -> sandbox execution) can run all the
+way to completion — driving the actual `interpreter.py` binary the same way
+a human would, just without a real paid model behind it.
+
+No network calls happen outside localhost. This does not replace live
+smoke tests against real providers (``tests/smoke/test_live_model_smoke.py``,
+``SMOKE_LIVE=1``); it exists to exercise the CLI plumbing for every mode
+when no provider API keys are configured.
+
+Usage as a script::
+
+    python scripts/live_stub_llm_server.py --port 11434
+
+Usage as a library (tests)::
+
+    from scripts.live_stub_llm_server import StubLLMServer
+    with StubLLMServer(port=11434):
+        ...
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import socket
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+
+def _port_free(port: int, host: str = "127.0.0.1") -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.2)
+        return sock.connect_ex((host, port)) != 0
+
+
+def _system_content(messages: list[dict]) -> str:
+    for msg in messages:
+        if msg.get("role") == "system":
+            content = msg.get("content")
+            return content if isinstance(content, str) else ""
+    return ""
+
+
+def _last_user_content(messages: list[dict]) -> str:
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            content = msg.get("content")
+            return content if isinstance(content, str) else ""
+    return ""
+
+
+def _chat_response(content: str, *, tool_calls: list[dict] | None = None) -> dict:
+    message: dict[str, Any] = {"role": "assistant", "content": content}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+        message["content"] = None
+    return {
+        "id": "chatcmpl-stub",
+        "object": "chat.completion",
+        "model": "local-model",
+        "choices": [{
+            "index": 0,
+            "message": message,
+            "finish_reason": "tool_calls" if tool_calls else "stop",
+        }],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+
+
+def _react_step_response(user_content: str) -> str:
+    """Cycle a ReAct agent through code -> execute -> review -> finish."""
+    if "Action: code" not in user_content:
+        return (
+            "Thought: I will write code to satisfy the task.\n"
+            "Action: code\n"
+            'Action Input: {"instruction": "Write minimal Python that satisfies the task"}\n'
+        )
+    if "Action: execute" not in user_content:
+        return (
+            "Thought: Now run the code I wrote.\n"
+            "Action: execute\n"
+            'Action Input: {"language": "python"}\n'
+        )
+    if "Action: review" not in user_content:
+        return (
+            "Thought: Check whether the execution satisfied the task.\n"
+            "Action: review\n"
+            "Action Input: {}\n"
+        )
+    return (
+        "Thought: Review passed, the task is complete.\n"
+        "Action: finish\n"
+        'Action Input: {"summary": "Task completed by stub agent"}\n'
+    )
+
+
+def _autoloop_response(messages: list[dict]) -> tuple[str | None, list[dict] | None]:
+    """AutoLoop (--yolo/native tool_calls): call one tool, then finish."""
+    already_ran_tool = any(msg.get("role") == "tool" for msg in messages)
+    if already_ran_tool:
+        return "Done — tool call completed.", None
+
+    task = _last_user_content(messages)
+
+    if re.search(r"search the web|web search|\bsearch\b", task, re.IGNORECASE):
+        query_match = re.search(r"search(?: the web)? for ['\"]?([^'\".]+)", task, re.IGNORECASE)
+        query = query_match.group(1).strip() if query_match else task[:60]
+        tool_calls = [{
+            "id": "call_stub_1",
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "arguments": json.dumps({"query": query, "max_results": 3}),
+            },
+        }]
+        return None, tool_calls
+
+    path_match = re.search(r"file(?:\s+named)?\s+([^\s,]+)", task, re.IGNORECASE)
+    content_match = re.search(r"content(?:ing)?\s+([^\s,.]+)", task, re.IGNORECASE)
+    path = path_match.group(1) if path_match else "yolo_stub_output.txt"
+    content = content_match.group(1) if content_match else "YOLO_STUB_OK"
+
+    tool_calls = [{
+        "id": "call_stub_1",
+        "type": "function",
+        "function": {
+            "name": "write_file",
+            "arguments": json.dumps({"path": path, "content": content}),
+        },
+    }]
+    return None, tool_calls
+
+
+def _route(body: dict) -> dict:
+    messages = body.get("messages") or []
+    tools = body.get("tools")
+    system = _system_content(messages)
+    user = _last_user_content(messages)
+
+    if tools:
+        content, tool_calls = _autoloop_response(messages)
+        return _chat_response(content or "", tool_calls=tool_calls)
+
+    if "ReAct code agent" in system:
+        return _chat_response(_react_step_response(user))
+
+    if "You are the Coder agent" in system:
+        return _chat_response("```python\nprint('stub agent: task executed')\n```")
+
+    if "You are the Reviewer agent" in system:
+        return _chat_response('{"passed": true, "reason": "execution succeeded"}')
+
+    if "You are the Debugger agent" in system:
+        return _chat_response("Root cause: stub. Fix: retry with corrected code.")
+
+    if "intent classifier" in system:
+        return _chat_response('{"intent": "code", "confidence": 0.95}')
+
+    if "task planner" in system:
+        return _chat_response(
+            '{"steps": ["Write code", "Execute", "Verify"], "mode": "code", '
+            '"language": "python", "complexity": "simple"}'
+        )
+
+    if "code output reviewer" in system:
+        return _chat_response('{"approved": true, "reason": "matches task"}')
+
+    # Default: classic single-shot fenced-code response (--cli, multi-agent Executor).
+    return _chat_response("```python\nprint('stub agent: task executed')\n```")
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):  # noqa: A002 - silence default access log
+        return
+
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(length)
+        try:
+            body = json.loads(raw or b"{}")
+        except json.JSONDecodeError:
+            body = {}
+        payload = json.dumps(_route(body)).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+class StubLLMServer:
+    """Context-manager wrapper: start/stop the stub on a background thread.
+
+    Refuses to bind (and marks itself as not-owned) if the port is already
+    occupied by something else — callers should treat that as "reuse the
+    existing server" rather than an error, mirroring the existing
+    ``tests/smoke/test_local_model_smoke.py`` pattern.
+    """
+
+    def __init__(self, host: str = "127.0.0.1", port: int = 11434):
+        self.host = host
+        self.port = port
+        self.server: HTTPServer | None = None
+        self.thread: threading.Thread | None = None
+        self.owned = False
+
+    def __enter__(self) -> "StubLLMServer":
+        if _port_free(self.port, self.host):
+            self.server = HTTPServer((self.host, self.port), _Handler)
+            self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+            self.thread.start()
+            self.owned = True
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self.owned and self.server is not None:
+            self.server.shutdown()
+            self.server.server_close()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=11434)
+    args = parser.parse_args()
+
+    httpd = HTTPServer((args.host, args.port), _Handler)
+    print(f"Stub LLM server listening on http://{args.host}:{args.port}/v1")
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass

--- a/tests/live/test_live_human_scenarios.py
+++ b/tests/live/test_live_human_scenarios.py
@@ -1,0 +1,214 @@
+"""Real end-to-end CLI runs, driven like a human user, for every mode/setting.
+
+Unlike the mocked unit suites (``tests/e2e/test_all_modes_e2e.py`` etc.), these
+tests spawn the actual ``interpreter.py`` binary as a subprocess with piped
+stdin — no ``unittest.mock`` on internal functions — and let the real
+pipeline run: argument parsing -> Interpreter boot -> litellm HTTP dispatch ->
+sandboxed execution -> real console output / real files on disk.
+
+Because this sandbox has no real LLM provider API keys (see
+``tests/smoke/test_live_model_smoke.py`` for the genuine-provider suite,
+which self-skips without keys), a protocol-aware local stub
+(``scripts/live_stub_llm_server.py``) stands in for the model. It recognizes
+which internal agent is calling (ReAct step / Coder / Reviewer / IntentRouter
+/ Planner / AutoLoop tool-use / classic single-shot) from the system prompt
+and replies with a protocol-correct message, so every mode actually runs to
+real completion instead of stopping at "local endpoint unreachable" (the
+soft-skip seen in ``scripts/run_live_scenarios.py`` today).
+
+Re-run: python -m unittest discover -s tests/live -v
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PYTHON = sys.executable
+sys.path.insert(0, str(ROOT))
+
+from scripts.live_stub_llm_server import StubLLMServer  # noqa: E402
+
+_TIMEOUT = 60
+
+
+def _run_cli(args: list[str], *, stdin: str = "", extra_env: dict | None = None) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["INTERPRETER_YES"] = "1"
+    env.update(extra_env or {})
+    return subprocess.run(
+        [PYTHON, str(ROOT / "interpreter.py"), *args],
+        cwd=str(ROOT),
+        input=stdin,
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT,
+        env=env,
+    )
+
+
+class LiveStubServerTestCase(unittest.TestCase):
+    """Base class: spins up the protocol-aware stub for every test in the class."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._stub = StubLLMServer(port=11434)
+        cls._stub.__enter__()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._stub.__exit__(None, None, None)
+
+
+class TestClassicCliRealRun(LiveStubServerTestCase):
+    def test_cli_mode_executes_real_code_and_produces_output(self):
+        proc = _run_cli(
+            ["--cli", "-m", "local-model", "-md", "code", "-dc"],
+            stdin="print classic cli smoke\ny\n/exit\n",
+        )
+        combined = proc.stdout + proc.stderr
+        self.assertEqual(proc.returncode, 0, combined)
+        self.assertIn("stub agent: task executed", combined)
+        self.assertIn('"status": "success"', combined)
+
+    def test_cli_slash_tools_and_memory_commands(self):
+        proc = _run_cli(
+            ["--cli", "-m", "local-model", "-md", "code"],
+            stdin="/tools list\n/memory stats\n/exit\n",
+        )
+        combined = proc.stdout + proc.stderr
+        self.assertEqual(proc.returncode, 0, combined)
+        self.assertIn("write_file", combined)
+        self.assertIn("execute_code", combined)
+
+
+class TestReActAgenticRealRun(LiveStubServerTestCase):
+    def test_agentic_mode_completes_full_react_cycle(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            task_file = Path(tmp) / "task.txt"
+            task_file.write_text("print a friendly greeting", encoding="utf-8")
+            proc = _run_cli(
+                ["--agentic", "-m", "local-model", "-md", "code", "-f", str(task_file), "--yes"],
+            )
+            combined = proc.stdout + proc.stderr
+            self.assertEqual(proc.returncode, 0, combined)
+            self.assertIn("Status: COMPLETED", combined)
+            self.assertIn("Steps: 4", combined)  # code -> execute -> review -> finish
+
+    def test_gemini_style_mode_shows_banner_and_completes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            task_file = Path(tmp) / "task.txt"
+            task_file.write_text("print a friendly greeting", encoding="utf-8")
+            proc = _run_cli(
+                ["--gemini-style", "-m", "local-model", "-md", "code", "-f", str(task_file), "--yes"],
+            )
+            combined = proc.stdout + proc.stderr
+            self.assertEqual(proc.returncode, 0, combined)
+            self.assertIn("/free", combined)
+            self.assertIn("/model", combined)
+            self.assertIn("Status: COMPLETED", combined)
+
+    def test_agentic_repl_model_and_free_slash_commands(self):
+        proc = _run_cli(
+            ["--agentic", "-m", "local-model", "-md", "code"],
+            stdin="/model local-model\n/free\n/help\n/exit\n",
+        )
+        combined = proc.stdout + proc.stderr
+        self.assertEqual(proc.returncode, 0, combined)
+        self.assertIn("Model switched to local-model", combined)
+        self.assertIn("Free / cheap LLM presets", combined)
+
+
+class TestYoloAutoLoopRealRun(LiveStubServerTestCase):
+    def test_yolo_writes_a_real_file_via_native_tool_calls(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            task_file = Path(tmp) / "task.txt"
+            out_file = Path(tmp) / "yolo_live_output.txt"
+            task_file.write_text(
+                f"Create a file named {out_file} with content YOLO_LIVE_OK using your tools.",
+                encoding="utf-8",
+            )
+            proc = _run_cli(
+                ["--yolo", "-m", "local-model", "-md", "code", "-f", str(task_file), "--yes"],
+            )
+            combined = proc.stdout + proc.stderr
+            self.assertEqual(proc.returncode, 0, combined)
+            self.assertTrue(out_file.exists(), combined)
+            self.assertEqual(out_file.read_text(encoding="utf-8").strip(), "YOLO_LIVE_OK")
+
+
+class TestMultiAgentPipelineRealRun(LiveStubServerTestCase):
+    def test_agent_pipeline_completes_intent_plan_execute_review(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            task_file = Path(tmp) / "task.txt"
+            task_file.write_text("print hello from agent pipeline", encoding="utf-8")
+            proc = _run_cli(
+                ["--cli", "--agent", "-m", "local-model", "-md", "code", "-f", str(task_file), "--yes", "-dc"],
+            )
+            combined = proc.stdout + proc.stderr
+            self.assertEqual(proc.returncode, 0, combined)
+            self.assertIn('"status": "success"', combined)
+
+
+class TestInteractiveSettingsWizardRealRun(LiveStubServerTestCase):
+    def test_settings_wizard_accepts_all_defaults_without_crashing(self):
+        # Every prompt in libs/terminal_ui.py::_collect_core_settings answered
+        # with a blank line (accept the shown default); real Rich Prompt.ask
+        # driven over piped stdin, exactly like a user mashing Enter.
+        blank_answers = "\n" * 14
+        proc = _run_cli(
+            ["--agentic", "-m", "local-model", "-md", "code"],
+            stdin=f"/settings\n{blank_answers}/exit\n",
+        )
+        combined = proc.stdout + proc.stderr
+        self.assertEqual(proc.returncode, 0, combined)
+        self.assertIn("Output format", combined)  # last prompt in the wizard was reached
+        self.assertNotIn("Traceback", combined)
+
+
+class TestSearchFlagRealNetworkAttempt(LiveStubServerTestCase):
+    def test_search_flag_enabled_reaches_real_network_boundary(self):
+        """--search drives the LLM to call the real web_search tool, which hits
+        real DuckDuckGo over the network (no API key needed) — the stub only
+        replaces the model, not the search tool or the network call it makes.
+
+        This sandbox's outbound network policy may not reach arbitrary
+        external hosts (only the pre-configured agent proxy), so a
+        connection failure here is an environment limitation, not a defect —
+        soft-skip it, mirroring the existing soft-skip convention in
+        scripts/run_live_scenarios.py. A real result is asserted when the
+        network is reachable.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            task_file = Path(tmp) / "task.txt"
+            task_file.write_text(
+                "Search the web for 'python programming language' and summarize the first result.",
+                encoding="utf-8",
+            )
+            proc = _run_cli(
+                [
+                    "--yolo", "-m", "local-model", "-md", "code",
+                    "-f", str(task_file), "--yes", "--search",
+                ],
+            )
+            combined = proc.stdout + proc.stderr
+            self.assertIn("Web search enabled", combined)
+            network_failure_markers = (
+                "connecterror", "connection refused", "tunnel error",
+                "name or service not known", "timed out", "ddgsexception",
+                "no results found",
+            )
+            if any(m in combined.lower() for m in network_failure_markers):
+                raise unittest.SkipTest(
+                    f"Soft-skip: sandbox network policy blocks live search: {combined[-400:]}"
+                )
+            self.assertEqual(proc.returncode, 0, combined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/live/test_live_human_scenarios.py
+++ b/tests/live/test_live_human_scenarios.py
@@ -38,6 +38,17 @@ _TIMEOUT = 60
 
 
 def _run_cli(args: list[str], *, stdin: str = "", extra_env: dict | None = None) -> subprocess.CompletedProcess:
+    """
+    Run the interpreter CLI as a subprocess with controlled input and environment.
+    
+    Parameters:
+    	args (list[str]): Command-line arguments passed to the interpreter.
+    	stdin (str): Text provided to the subprocess through standard input.
+    	extra_env (dict | None): Environment variables to add or override.
+    
+    Returns:
+    	subprocess.CompletedProcess: The completed CLI subprocess result.
+    """
     env = os.environ.copy()
     env["INTERPRETER_YES"] = "1"
     env.update(extra_env or {})
@@ -57,11 +68,15 @@ class LiveStubServerTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        """Start the shared stub LLM server for the test class."""
         cls._stub = StubLLMServer(port=11434)
         cls._stub.__enter__()
 
     @classmethod
     def tearDownClass(cls):
+        """
+        Stop the shared stub LLM server after all tests in the class have completed.
+        """
         cls._stub.__exit__(None, None, None)
 
 


### PR DESCRIPTION
## Summary

The Gemini-style interface work itself (banner, tips, status bar, ReAct step UX, missing-binary recovery) was already merged into `develop` in an earlier session. This PR closes a real gap flagged in follow-up review: the existing "live" test suites (`scripts/run_live_scenarios.py`, `tests/smoke/test_live_model_smoke.py`) self-skip every LLM-dependent scenario when no provider API key is configured — which is always, in this sandbox — so `--agentic`, `--gemini-style`, `--yolo`, and `--agent` never actually ran to completion; only plain `--cli` fenced-code responses were exercised.

- Add `scripts/live_stub_llm_server.py`, a protocol-aware OpenAI-compatible stub that recognizes which internal agent is calling (ReAct step / Coder / Reviewer / Debugger / IntentRouter / Planner / multi-agent Reviewer / AutoLoop native `tool_calls`) from the system prompt and replies with a protocol-correct message, so the real, unmodified pipeline runs all the way through instead of stopping at "local endpoint unreachable".
- Add `tests/live/test_live_human_scenarios.py`, which spawns the actual `interpreter.py` binary as a subprocess with piped stdin — **no `unittest.mock` on internals** — covering:
  - Classic `--cli` mode (real sandbox execution)
  - Full ReAct `--agentic` cycle (code → execute → review → finish, `Status: COMPLETED`)
  - `--gemini-style` banner + completion
  - `--yolo` writing a real file to disk via native `tool_calls`
  - The `--agent` multi-agent pipeline (IntentRouter → Planner → Executor → Reviewer)
  - The full `/settings` wizard driven over piped stdin (14 prompts, all defaults)
  - `/model`, `/free`, `/tools`, `/memory` slash commands
  - `--search` driving the LLM to call the real `web_search` tool — a genuine outbound DuckDuckGo request, soft-skipped only when the sandbox's own network policy blocks it (verified: it does, via a real `ConnectError`, not a fake pass)
- Document the new suite in `AGENTS.md`.

## Test plan

- [x] `python -m unittest discover -s tests/live -p 'test_live_human_scenarios.py' -v` — 9 tests, 8 pass, 1 soft-skip (network policy)
- [x] `python -m unittest discover -s tests` — 1380 tests, all pass (7 skipped, pre-existing + the one above)
- [x] `flake8 . --select=E9,F63,F7,F82 --exclude=.venv` — clean
- [x] Manually verified each mode by hand before writing assertions (banner render, `Status: COMPLETED`, real file write, real JSON output)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LLcftcnxJtrA43abmkuNnn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added live end-to-end coverage for classic CLI use, agent workflows, automated tool use, multi-agent execution, interactive settings, and search.
  * Tests run the actual command-line application with real subprocesses and user-style input.
  * Added local protocol-compatible testing support that works without provider API keys or mocked application internals.

* **Documentation**
  * Documented the new live scenario test command and usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->